### PR TITLE
Switching feature

### DIFF
--- a/source/SylphyHorn/Models/HookService.cs
+++ b/source/SylphyHorn/Models/HookService.cs
@@ -82,6 +82,18 @@ namespace SylphyHorn.Models
 				VisualHelper.InvokeOnUIDispatcher(() => this.MoveToNew()?.Switch());
 				args.Handled = true;
 			}
+
+			if (ShortcutSettings.SwitchLeft.Value != null &&
+				ShortcutSettings.SwitchLeft.Value == args.ShortcutKey)
+			{
+				VisualHelper.InvokeOnUIDispatcher(() => this.GetLeftDesktop()?.Switch());
+			}
+
+			if (ShortcutSettings.SwitchRight.Value != null &&
+				ShortcutSettings.SwitchRight.Value == args.ShortcutKey)
+			{
+				VisualHelper.InvokeOnUIDispatcher(() => this.GetRightDesktop()?.Switch());
+			}
 		}
 
 		private VirtualDesktop MoveToLeft()
@@ -183,6 +195,38 @@ namespace SylphyHorn.Models
 				return newone;
 			}
 
+			return null;
+		}
+
+		private VirtualDesktop GetLeftDesktop()
+		{
+			var current = VirtualDesktop.Current;
+			if (current != null)
+			{
+				var left = current.GetLeft();
+				if (left == null && GeneralSettings.LoopDesktop)
+				{
+					var desktops = VirtualDesktop.GetDesktops();
+					if (desktops.Length >= 2) left = desktops.Last();
+				}
+				return left;
+			}
+			return null;
+		}
+
+		private VirtualDesktop GetRightDesktop()
+		{
+			var current = VirtualDesktop.Current;
+			if (current != null)
+			{
+				var right = current.GetRight();
+				if (right == null && GeneralSettings.LoopDesktop)
+				{
+					var desktops = VirtualDesktop.GetDesktops();
+					if (desktops.Length >= 2) right = desktops.First();
+				}
+				return right;
+			}
 			return null;
 		}
 

--- a/source/SylphyHorn/Models/HookService.cs
+++ b/source/SylphyHorn/Models/HookService.cs
@@ -87,12 +87,14 @@ namespace SylphyHorn.Models
 				ShortcutSettings.SwitchLeft.Value == args.ShortcutKey)
 			{
 				VisualHelper.InvokeOnUIDispatcher(() => this.GetLeftDesktop()?.Switch());
+				args.Handled = true;
 			}
 
 			if (ShortcutSettings.SwitchRight.Value != null &&
 				ShortcutSettings.SwitchRight.Value == args.ShortcutKey)
 			{
 				VisualHelper.InvokeOnUIDispatcher(() => this.GetRightDesktop()?.Switch());
+				args.Handled = true;
 			}
 		}
 

--- a/source/SylphyHorn/Models/Settings.cs
+++ b/source/SylphyHorn/Models/Settings.cs
@@ -66,6 +66,12 @@ namespace SylphyHorn.Models
 		public static SerializableProperty<ShortcutKey?> MoveNewAndSwitch { get; }
 			= new SerializableProperty<ShortcutKey?>(GetKey(), Providers.Local, new ShortcutKey(Key.D, Key.LeftCtrl, Key.LeftAlt, Key.LWin));
 
+		public static SerializableProperty<ShortcutKey?> SwitchLeft { get; }
+			= new SerializableProperty<ShortcutKey?>(GetKey(), Providers.Local);
+
+		public static SerializableProperty<ShortcutKey?> SwitchRight { get; }
+			= new SerializableProperty<ShortcutKey?>(GetKey(), Providers.Local);
+
 
 		private static string GetKey([CallerMemberName] string caller = "")
 		{

--- a/source/SylphyHorn/Views/SettingsWindow.xaml
+++ b/source/SylphyHorn/Views/SettingsWindow.xaml
@@ -201,6 +201,30 @@
 								<controls:ShortcutKeyBox Current="{Binding Source={x:Static models:ShortcutSettings.MoveNewAndSwitch}, Path=Value, Mode=TwoWay}" />
 							</UniformGrid>
 						</Grid>
+
+						<TextBlock Text="Switch virtual desktop"
+								   Style="{DynamicResource HeaderStyleKey}" />
+						<Grid Margin="8,0,0,0">
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto"
+												  SharedSizeGroup="KeyHeader" />
+								<ColumnDefinition Width="8" />
+								<ColumnDefinition Width="*" />
+							</Grid.ColumnDefinitions>
+							<UniformGrid Columns="1">
+								<TextBlock Text="Switch to Right (Default)" />
+								<TextBlock Text="Switch to Left (Default)" />
+								<TextBlock Text="Switch to Right" />
+								<TextBlock Text="Switch to Left" />
+							</UniformGrid>
+							<UniformGrid Grid.Column="2"
+										 Columns="1">
+								<TextBlock Text="Ctrl + Win + &lt;- (provided by Windows)" />
+								<TextBlock Text="Ctrl + Win + -&gt; (provided by Windows)" />
+								<controls:ShortcutKeyBox Current="{Binding Source={x:Static models:ShortcutSettings.SwitchLeft}, Path=Value, Mode=TwoWay}" />
+								<controls:ShortcutKeyBox Current="{Binding Source={x:Static models:ShortcutSettings.SwitchRight}, Path=Value, Mode=TwoWay}" />
+							</UniformGrid>
+						</Grid>
 					</StackPanel>
 				</ScrollViewer>
 			</TabItem>


### PR DESCRIPTION
Added a feature to switch between virtual desktops by additional shortcut keys.
A screenshot of the updated settings dialog is available here: http://t.co/u24QnGsfrp

[Changes]
 - Add 2 shortcut settings
	- SwitchLeft (Default: N/A)
	- SwitchRight (Default: N/A)
	
 - Add GetLeftDesktop() and GetRightDesktop() private methods to HookService class
 - Add if conditions to KeyHookOnPressed() in HookService class to handle SwitchLeft / SwitchRight
 
 - Add "Switch virtual desktop" section to "Shortcut key" section in settings dialog


[Tests]
Manual tests
 - Set shortcut keys to switching feature, verify desktop is switched by the shortcut keys.
 	- with "Loop" option enabled/disabled
 - Verify default shortcut keys (Ctrl + Win + <-/->) still work correctly.