### PR TITLE
"Sticky window" or "Pin window" Feature

### DIFF
--- a/source/SylphyHorn/Interop/NativeMethods.cs
+++ b/source/SylphyHorn/Interop/NativeMethods.cs
@@ -23,5 +23,15 @@ namespace SylphyHorn.Interop
 
 		[DllImport("Dwmapi.dll")]
 		public static extern void DwmGetColorizationColor([Out] out int pcrColorization, [Out] out bool pfOpaqueBlend);
-	}
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool IsWindow(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
+        public static extern int OpenInputDesktop(int dwFlags, bool fInherit, int dwDesiredAccess);
+
+        [DllImport("user32.dll")]
+        public static extern int GetWindowText(int hWnd, StringBuilder text, int count);
+    }
 }

--- a/source/SylphyHorn/Models/Helper.cs
+++ b/source/SylphyHorn/Models/Helper.cs
@@ -91,7 +91,7 @@ namespace SylphyHorn.Models
     }
 
     /*
-    * The VDMHelper need to be a singleton or else it will create multiple instance of the process VDMHelper32.Dll
+    * The VDMHelper need to be a singleton or else it will create multiple instance of the process VDMHelper32.exe
     * This can cause failure when moving window.
     */
     internal class VDMHelper

--- a/source/SylphyHorn/Models/Helper.cs
+++ b/source/SylphyHorn/Models/Helper.cs
@@ -14,6 +14,7 @@ using Livet;
 using MetroRadiance;
 using Microsoft.Win32;
 using SylphyHorn.Interop;
+using VDMHelperCLR.Common;
 
 namespace SylphyHorn.Models
 {
@@ -63,9 +64,53 @@ namespace SylphyHorn.Models
 			var howner = NativeMethods.GetWindow(hwnd, 4 /* GW_OWNER */);
 			return howner == IntPtr.Zero ? hwnd : howner;
 		}
-	}
 
-	internal static class VisualHelper
+        public static bool IsWindow(IntPtr hWnd)
+        {
+            return NativeMethods.IsWindow(hWnd);
+        }
+
+        public static int GetWindowThreadProcessId(IntPtr hWnd)
+        {
+            int processId = 0;
+            NativeMethods.GetWindowThreadProcessId(hWnd, out processId);
+            return processId;
+        }
+
+        public static string GetWindowText(int hWnd)
+        {
+            var windowText = new StringBuilder();
+            if (NativeMethods.GetWindowText(hWnd, windowText, 50) > 0) 
+            {
+                return windowText.ToString();
+            }
+
+            return string.Empty;
+        }
+    }
+
+    /*
+    * The VDMHelper need to be a singleton or else it will create multiple instance of the process VDMHelper32.Dll
+    * This can cause failure when moving window.
+    */
+    internal class VDMHelper
+    {
+        private static IVdmHelper instancehelper;
+        public static IVdmHelper helper
+        {
+            get
+            {
+                if (instancehelper == null)
+                {
+                    instancehelper = VdmHelperFactory.CreateInstance();
+                    helper.Init();
+                }
+                return instancehelper;
+            }
+        }
+    }
+
+    internal static class VisualHelper
 	{
 		public static void InvokeOnUIDispatcher(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
 		{

--- a/source/SylphyHorn/Models/Helper.cs
+++ b/source/SylphyHorn/Models/Helper.cs
@@ -79,8 +79,9 @@ namespace SylphyHorn.Models
 
         public static string GetWindowText(int hWnd)
         {
-            var windowText = new StringBuilder();
-            if (NativeMethods.GetWindowText(hWnd, windowText, 50) > 0) 
+            const int bufferSize = 256;
+            var windowText = new StringBuilder(bufferSize);
+            if (NativeMethods.GetWindowText(hWnd, windowText, bufferSize) > 0) 
             {
                 return windowText.ToString();
             }

--- a/source/SylphyHorn/Models/HookService.cs
+++ b/source/SylphyHorn/Models/HookService.cs
@@ -21,9 +21,8 @@ namespace SylphyHorn.Models
 			this.detector.Pressed += this.KeyHookOnPressed;
 			this.detector.Start();
 
-			this.helper = VdmHelperFactory.CreateInstance();
-			this.helper.Init();
-		}
+            this.helper = VDMHelper.helper;
+        }
 
 		public IDisposable Suspend()
 		{
@@ -47,14 +46,14 @@ namespace SylphyHorn.Models
 			if (ShortcutSettings.MoveLeft.Value != null &&
 				ShortcutSettings.MoveLeft.Value == args.ShortcutKey)
 			{
-				VisualHelper.InvokeOnUIDispatcher(() => this.MoveToLeft());
+				VisualHelper.InvokeOnUIDispatcher(() => this.MoveToLeft()?.MoveSticky());
 				args.Handled = true;
 			}
 
 			if (ShortcutSettings.MoveLeftAndSwitch.Value != null &&
 				ShortcutSettings.MoveLeftAndSwitch.Value == args.ShortcutKey)
 			{
-				VisualHelper.InvokeOnUIDispatcher(() => this.MoveToLeft()?.Switch());
+				VisualHelper.InvokeOnUIDispatcher(() => this.MoveToLeft()?.MoveSticky().Switch());
 				args.Handled = true;
 			}
 
@@ -68,7 +67,7 @@ namespace SylphyHorn.Models
 			if (ShortcutSettings.MoveRightAndSwitch.Value != null &&
 				ShortcutSettings.MoveRightAndSwitch.Value == args.ShortcutKey)
 			{
-				VisualHelper.InvokeOnUIDispatcher(() => this.MoveToRight()?.Switch());
+				VisualHelper.InvokeOnUIDispatcher(() => this.MoveToRight()?.MoveSticky().Switch());
 				args.Handled = true;
 			}
 
@@ -82,7 +81,7 @@ namespace SylphyHorn.Models
 			if (ShortcutSettings.MoveNewAndSwitch.Value != null &&
 				ShortcutSettings.MoveNewAndSwitch.Value == args.ShortcutKey)
 			{
-				VisualHelper.InvokeOnUIDispatcher(() => this.MoveToNew()?.Switch());
+				VisualHelper.InvokeOnUIDispatcher(() => this.MoveToNew()?.MoveSticky().Switch());
 				args.Handled = true;
 			}
 
@@ -91,7 +90,7 @@ namespace SylphyHorn.Models
 			{
 				if (GeneralSettings.OverrideOSDefaultKeyCombination)
 				{
-					VisualHelper.InvokeOnUIDispatcher(() => PrepareSwitchToLeft()?.Switch());
+					VisualHelper.InvokeOnUIDispatcher(() => PrepareSwitchToLeft()?.MoveSticky().Switch());
 					args.Handled = true;
 				}
 			}
@@ -101,11 +100,17 @@ namespace SylphyHorn.Models
 			{
 				if (GeneralSettings.OverrideOSDefaultKeyCombination)
 				{
-					VisualHelper.InvokeOnUIDispatcher(() => PrepareSwitchToRight()?.Switch());
+					VisualHelper.InvokeOnUIDispatcher(() => PrepareSwitchToRight()?.MoveSticky().Switch());
 					args.Handled = true;
 				}
 			}
-		}
+
+            if (ShortcutSettings.PinWindows.Value != null &&
+                ShortcutSettings.PinWindows.Value == args.ShortcutKey)
+            {
+                VisualHelper.InvokeOnUIDispatcher(() => StickyWindowsManager.Instance.ToggleStickyWindow());
+            }
+        }
 
 		private static VirtualDesktop PrepareSwitchToLeft()
 		{

--- a/source/SylphyHorn/Models/NotificationService.cs
+++ b/source/SylphyHorn/Models/NotificationService.cs
@@ -17,7 +17,8 @@ namespace SylphyHorn.Models
 		public NotificationService()
 		{
 			VirtualDesktop.CurrentChanged += this.VirtualDesktopOnCurrentChanged;
-		}
+            StickyWindowsManager.ToggleStickyWindowEvent += this.ShowToggleStickyWindow;
+        }
 
 		private void VirtualDesktopOnCurrentChanged(object sender, VirtualDesktopChangedEventArgs e)
 		{
@@ -29,22 +30,38 @@ namespace SylphyHorn.Models
 				var newIndex = Array.IndexOf(desktops, e.NewDesktop) + 1;
 
 				this.currentNotificationWindow?.Dispose();
-				this.currentNotificationWindow = ShowWindow(newIndex);
+
+                var vmodel = new NotificationWindowViewModel
+                {
+                    Title = ProductInfo.Title,
+                    Header = "Virtual Desktop Switched",
+                    Body = "Current Desktop: Desktop " + newIndex,
+                };
+                this.currentNotificationWindow = ShowWindow(vmodel);
 			});
 		}
 
-		private static IDisposable ShowWindow(int index)
+
+        private void ShowToggleStickyWindow(object sender, string body)
+        {
+            this.currentNotificationWindow?.Dispose();
+
+            var vmodel = new NotificationWindowViewModel
+            {
+                Title = ProductInfo.Title,
+                Header = "Window Pin Toggled",
+                Body = body
+            };
+            this.currentNotificationWindow = ShowWindow(vmodel);
+        }
+
+		private static IDisposable ShowWindow(NotificationWindowViewModel vm)
 		{
-			var vmodel = new NotificationWindowViewModel
-			{
-				Title = ProductInfo.Title,
-				Header = "Virtual Desktop Switched",
-				Body = "Current Desktop: Desktop " + index,
-			};
+			
 			var source = new CancellationTokenSource();
 			var window = new NotificationWindow
 			{
-				DataContext = vmodel,
+				DataContext = vm,
 			};
 			window.Show();
 

--- a/source/SylphyHorn/Models/NotificationService.cs
+++ b/source/SylphyHorn/Models/NotificationService.cs
@@ -74,6 +74,7 @@ namespace SylphyHorn.Models
 		public void Dispose()
 		{
 			VirtualDesktop.CurrentChanged -= this.VirtualDesktopOnCurrentChanged;
-		}
+            StickyWindowsManager.ToggleStickyWindowEvent -= this.ShowToggleStickyWindow;
+        }
 	}
 }

--- a/source/SylphyHorn/Models/Settings.cs
+++ b/source/SylphyHorn/Models/Settings.cs
@@ -75,6 +75,9 @@ namespace SylphyHorn.Models
         public static SerializableProperty<ShortcutKey?> SwitchToRight { get; }
             = new SerializableProperty<ShortcutKey?>(GetKey(), Providers.Local, new ShortcutKey(Key.Right, Key.LeftCtrl, Key.LWin));
 
+        public static SerializableProperty<ShortcutKey?> PinWindows { get; }
+            = new SerializableProperty<ShortcutKey?>(GetKey(), Providers.Local, new ShortcutKey(Key.P, Key.LeftCtrl, Key.LeftAlt, Key.LWin));
+
 
         private static string GetKey([CallerMemberName] string caller = "")
 		{

--- a/source/SylphyHorn/Models/StickyWindowsManager.cs
+++ b/source/SylphyHorn/Models/StickyWindowsManager.cs
@@ -56,13 +56,11 @@ namespace SylphyHorn.Models
             }
 
             Console.WriteLine(StickyWindows.ToString());
-            Console.WriteLine("PRocess ID:" + InteropHelper.GetWindowThreadProcessId(hWnd));
+            Console.WriteLine("Process ID:" + InteropHelper.GetWindowThreadProcessId(hWnd));
         }
 
         private void VirtualDesktopOnCurrentChanged(object sender, VirtualDesktopChangedEventArgs e)
         {
-            if (!GeneralSettings.NotificationWhenSwitchedDesktop) return;
-
             VisualHelper.InvokeOnUIDispatcher(() =>
             {
                 var desktops = VirtualDesktop.GetDesktops();
@@ -75,8 +73,6 @@ namespace SylphyHorn.Models
                     MoveSticky(newDesktopId);
                 }
             });
-
-
         }
 
         public void MoveSticky(Guid id)

--- a/source/SylphyHorn/Models/StickyWindowsManager.cs
+++ b/source/SylphyHorn/Models/StickyWindowsManager.cs
@@ -18,7 +18,7 @@ namespace SylphyHorn.Models
 
         private static StickyWindowsManager instanceStickyWindowsManager;
 
-        private static Guid LastDesktopId;
+        private static Guid lastDesktopId;
 
         #endregion
 
@@ -45,17 +45,7 @@ namespace SylphyHorn.Models
 
         #region Public Properties
 
-        public static StickyWindowsManager Instance
-        {
-            get
-            {
-                if (instanceStickyWindowsManager == null)
-                {
-                    instanceStickyWindowsManager = new StickyWindowsManager();
-                }
-                return instanceStickyWindowsManager;
-            }
-        }
+        public static StickyWindowsManager Instance => instanceStickyWindowsManager ?? (instanceStickyWindowsManager = new StickyWindowsManager());
 
         #endregion
 
@@ -137,7 +127,7 @@ namespace SylphyHorn.Models
 
         public void MoveSticky(Guid id)
         {
-            LastDesktopId = id;
+            lastDesktopId = id;
             var tasks = this.CreateMovingTask(id);
 
             this.currentMovingOperation?.Dispose();
@@ -147,21 +137,17 @@ namespace SylphyHorn.Models
         public void ToggleStickyWindow()
         {
             var hWnd = InteropHelper.GetForegroundWindowEx();
-            if (hWnd == null)
-            {
-                return;
-            }
             var title = InteropHelper.GetWindowText((int)hWnd);
 
             if (StickyWindows.Contains(hWnd))
             {
                 StickyWindows.Remove(hWnd);
-                ToggleStickyWindowEvent.Invoke(this, title + ": Is remove from pinned windows");
+                ToggleStickyWindowEvent?.Invoke(this, title + ": Is remove from pinned windows");
             }
             else
             {
                 StickyWindows.Add(hWnd);
-                ToggleStickyWindowEvent.Invoke(this, title + ": Is now pinned");
+                ToggleStickyWindowEvent?.Invoke(this, title + ": Is now pinned");
             }
 
             Console.WriteLine(StickyWindows.ToString());
@@ -181,7 +167,7 @@ namespace SylphyHorn.Models
                         var newIndex = Array.IndexOf(desktops, e.NewDesktop);
                         var newDesktopId = desktops[newIndex].Id;
 
-                        if (!GeneralSettings.OverrideOSDefaultKeyCombination || LastDesktopId == null || LastDesktopId != newDesktopId)
+                        if (!GeneralSettings.OverrideOSDefaultKeyCombination || lastDesktopId != newDesktopId)
                         {
                             this.MoveSticky(newDesktopId);
                         }

--- a/source/SylphyHorn/Models/StickyWindowsManager.cs
+++ b/source/SylphyHorn/Models/StickyWindowsManager.cs
@@ -1,0 +1,162 @@
+﻿using MetroTrilithon.Lifetime;
+using SylphyHorn.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using WindowsDesktop;
+
+namespace SylphyHorn.Models
+{
+    public class StickyWindowsManager : IDisposable
+    {
+        private static StickyWindowsManager instanceStickyWindowsManager;
+        private IDisposable currentMovingOperation;
+        public static HashSet<IntPtr> StickyWindows = new HashSet<IntPtr>();
+        public static event EventHandler<string> ToggleStickyWindowEvent;
+        private static Guid LastDesktopId;
+        private StickyWindowsManager()
+        {
+            VirtualDesktop.CurrentChanged += this.VirtualDesktopOnCurrentChanged;
+        }
+
+        public static StickyWindowsManager Instance
+        {
+            get
+            {
+                if (instanceStickyWindowsManager == null)
+                {
+                    instanceStickyWindowsManager = new StickyWindowsManager();
+                }
+                return instanceStickyWindowsManager;
+            }
+        }
+
+
+        public void ToggleStickyWindow()
+        {
+            var hWnd = InteropHelper.GetForegroundWindowEx();
+            if (hWnd == null)
+            {
+                return;
+            }
+            var title = InteropHelper.GetWindowText((int)hWnd);
+
+            if (StickyWindows.Contains(hWnd))
+            {
+                StickyWindows.Remove(hWnd);
+                ToggleStickyWindowEvent.Invoke(this, title + ": Is remove from Pins windows");
+            }
+            else
+            {
+                StickyWindows.Add(hWnd);
+                ToggleStickyWindowEvent.Invoke(this, title + ": Is now Pin");
+            }
+
+            Console.WriteLine(StickyWindows.ToString());
+            Console.WriteLine("PRocess ID:" + InteropHelper.GetWindowThreadProcessId(hWnd));
+        }
+
+        private void VirtualDesktopOnCurrentChanged(object sender, VirtualDesktopChangedEventArgs e)
+        {
+            if (!GeneralSettings.NotificationWhenSwitchedDesktop) return;
+
+            VisualHelper.InvokeOnUIDispatcher(() =>
+            {
+                var desktops = VirtualDesktop.GetDesktops();
+                var newIndex = Array.IndexOf(desktops, e.NewDesktop);
+                var newDesktopId = desktops[newIndex].Id;
+
+                if (!GeneralSettings.OverrideOSDefaultKeyCombination ||
+                    LastDesktopId == null || LastDesktopId != newDesktopId)
+                {
+                    MoveSticky(newDesktopId);
+                }
+            });
+
+
+        }
+
+        public void MoveSticky(Guid id)
+        {
+            LastDesktopId = id;
+            var tasks = CreateMovingTask(id);
+
+            currentMovingOperation?.Dispose();
+            currentMovingOperation = Iterate(tasks);
+        }
+
+        /*
+        * This create multiple task that will ve executed in sequence order. This is needed to prevent a concurrent probleme that
+        * occur when we move multiple windows of a save process ( multiple chrome window for exemple )
+        */
+        public IEnumerable<Task> CreateMovingTask(Guid id)
+        {
+            var invalids = new HashSet<IntPtr>();
+            foreach (var sticky in StickyWindows)
+            {
+                if (InteropHelper.IsWindow(sticky))
+                {
+                    yield return new Task(() =>
+                    {
+                        VDMHelper.helper.MoveWindowToDesktop(sticky, id);
+                    });
+                }
+                else
+                {
+                    invalids.Add(sticky);
+                }
+            }
+            StickyWindows.ExceptWith(invalids);
+        }
+        public IDisposable Iterate(IEnumerable<Task> asyncIterator)
+        {
+            if (asyncIterator == null) throw new ArgumentNullException("asyncIterator");
+
+            var enumerator = asyncIterator.GetEnumerator();
+            if (enumerator == null) throw new InvalidOperationException("Invalid enumerable - GetEnumerator returned null");
+
+            var source = new CancellationTokenSource();
+            var tcs = new TaskCompletionSource<object>();
+            tcs.Task.ContinueWith(_ => enumerator.Dispose(), TaskContinuationOptions.ExecuteSynchronously);
+
+            Action<Task> recursiveBody = null;
+            recursiveBody = delegate
+           {
+               try
+               {
+                   if (enumerator.MoveNext())
+                   {
+                       Task.Delay(TimeSpan.FromMilliseconds(15), source.Token)
+                                               .ContinueWith(_ =>
+                                               {
+                                                   enumerator.Current.Start();
+                                                   enumerator.Current.ContinueWith(recursiveBody, TaskContinuationOptions.ExecuteSynchronously);
+                                               }, TaskScheduler.FromCurrentSynchronizationContext());
+                   }
+                   else tcs.TrySetResult(null);
+               }
+               catch (Exception exc) { tcs.TrySetException(exc); }
+           };
+
+            recursiveBody(null);
+            return Disposable.Create(() => source.Cancel());
+        }
+
+        public void Dispose()
+        {
+            VirtualDesktop.CurrentChanged -= this.VirtualDesktopOnCurrentChanged;
+        }
+    }
+
+    public static class VirtualDesktopExtention
+    {
+        public static VirtualDesktop MoveSticky(this VirtualDesktop desktop)
+        {
+            StickyWindowsManager.Instance.MoveSticky(desktop.Id);
+            return desktop;
+        }
+    }
+}

--- a/source/SylphyHorn/Models/StickyWindowsManager.cs
+++ b/source/SylphyHorn/Models/StickyWindowsManager.cs
@@ -1,26 +1,49 @@
-﻿using MetroTrilithon.Lifetime;
-using SylphyHorn.ViewModels;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using WindowsDesktop;
+﻿using System;
 
 namespace SylphyHorn.Models
 {
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using WindowsDesktop;
+
+    using MetroTrilithon.Lifetime;
+
     public class StickyWindowsManager : IDisposable
     {
-        private static StickyWindowsManager instanceStickyWindowsManager;
-        private IDisposable currentMovingOperation;
+        #region Static Fields
+
         public static HashSet<IntPtr> StickyWindows = new HashSet<IntPtr>();
-        public static event EventHandler<string> ToggleStickyWindowEvent;
+
+        private static StickyWindowsManager instanceStickyWindowsManager;
+
         private static Guid LastDesktopId;
+
+        #endregion
+
+        #region Fields
+
+        private IDisposable currentMovingOperation;
+
+        #endregion
+
+        #region Constructors and Destructors
+
         private StickyWindowsManager()
         {
             VirtualDesktop.CurrentChanged += this.VirtualDesktopOnCurrentChanged;
         }
+
+        #endregion
+
+        #region Public Events
+
+        public static event EventHandler<string> ToggleStickyWindowEvent;
+
+        #endregion
+
+        #region Public Properties
 
         public static StickyWindowsManager Instance
         {
@@ -34,6 +57,92 @@ namespace SylphyHorn.Models
             }
         }
 
+        #endregion
+
+        #region Public Methods and Operators
+
+        /*
+        * This create multiple task that will be executed in sequence order. This is needed to prevent a concurrent probleme that
+        * occur when we move multiple windows of a same process ( multiple chrome window for exemple )
+        */
+
+        public IEnumerable<Task> CreateMovingTask(Guid id)
+        {
+            var invalids = new HashSet<IntPtr>();
+            foreach (var sticky in StickyWindows)
+            {
+                if (InteropHelper.IsWindow(sticky))
+                {
+                    yield return new Task(() => { VDMHelper.helper.MoveWindowToDesktop(sticky, id); });
+                }
+                else
+                {
+                    invalids.Add(sticky);
+                }
+            }
+            StickyWindows.ExceptWith(invalids);
+        }
+
+        public void Dispose()
+        {
+            VirtualDesktop.CurrentChanged -= this.VirtualDesktopOnCurrentChanged;
+        }
+
+        public IDisposable Iterate(IEnumerable<Task> asyncIterator)
+        {
+            if (asyncIterator == null)
+            {
+                throw new ArgumentNullException("asyncIterator");
+            }
+
+            var enumerator = asyncIterator.GetEnumerator();
+            if (enumerator == null)
+            {
+                throw new InvalidOperationException("Invalid enumerable - GetEnumerator returned null");
+            }
+
+            var source = new CancellationTokenSource();
+            var tcs = new TaskCompletionSource<object>();
+            tcs.Task.ContinueWith(_ => enumerator.Dispose(), TaskContinuationOptions.ExecuteSynchronously);
+
+            Action<Task> recursiveBody = null;
+            recursiveBody = delegate
+                {
+                    try
+                    {
+                        if (enumerator.MoveNext())
+                        {
+                            Task.Delay(TimeSpan.FromMilliseconds(15), source.Token).ContinueWith(
+                                _ =>
+                                    {
+                                        enumerator.Current.Start();
+                                        enumerator.Current.ContinueWith(recursiveBody, TaskContinuationOptions.ExecuteSynchronously);
+                                    },
+                                TaskScheduler.FromCurrentSynchronizationContext());
+                        }
+                        else
+                        {
+                            tcs.TrySetResult(null);
+                        }
+                    }
+                    catch (Exception exc)
+                    {
+                        tcs.TrySetException(exc);
+                    }
+                };
+
+            recursiveBody(null);
+            return Disposable.Create(() => source.Cancel());
+        }
+
+        public void MoveSticky(Guid id)
+        {
+            LastDesktopId = id;
+            var tasks = this.CreateMovingTask(id);
+
+            this.currentMovingOperation?.Dispose();
+            this.currentMovingOperation = this.Iterate(tasks);
+        }
 
         public void ToggleStickyWindow()
         {
@@ -59,100 +168,39 @@ namespace SylphyHorn.Models
             Console.WriteLine("Process ID:" + InteropHelper.GetWindowThreadProcessId(hWnd));
         }
 
+        #endregion
+
+        #region Methods
+
         private void VirtualDesktopOnCurrentChanged(object sender, VirtualDesktopChangedEventArgs e)
         {
-            VisualHelper.InvokeOnUIDispatcher(() =>
-            {
-                var desktops = VirtualDesktop.GetDesktops();
-                var newIndex = Array.IndexOf(desktops, e.NewDesktop);
-                var newDesktopId = desktops[newIndex].Id;
-
-                if (!GeneralSettings.OverrideOSDefaultKeyCombination ||
-                    LastDesktopId == null || LastDesktopId != newDesktopId)
-                {
-                    MoveSticky(newDesktopId);
-                }
-            });
-        }
-
-        public void MoveSticky(Guid id)
-        {
-            LastDesktopId = id;
-            var tasks = CreateMovingTask(id);
-
-            currentMovingOperation?.Dispose();
-            currentMovingOperation = Iterate(tasks);
-        }
-
-        /*
-        * This create multiple task that will be executed in sequence order. This is needed to prevent a concurrent probleme that
-        * occur when we move multiple windows of a same process ( multiple chrome window for exemple )
-        */
-        public IEnumerable<Task> CreateMovingTask(Guid id)
-        {
-            var invalids = new HashSet<IntPtr>();
-            foreach (var sticky in StickyWindows)
-            {
-                if (InteropHelper.IsWindow(sticky))
-                {
-                    yield return new Task(() =>
+            VisualHelper.InvokeOnUIDispatcher(
+                () =>
                     {
-                        VDMHelper.helper.MoveWindowToDesktop(sticky, id);
+                        var desktops = VirtualDesktop.GetDesktops();
+                        var newIndex = Array.IndexOf(desktops, e.NewDesktop);
+                        var newDesktopId = desktops[newIndex].Id;
+
+                        if (!GeneralSettings.OverrideOSDefaultKeyCombination || LastDesktopId == null || LastDesktopId != newDesktopId)
+                        {
+                            this.MoveSticky(newDesktopId);
+                        }
                     });
-                }
-                else
-                {
-                    invalids.Add(sticky);
-                }
-            }
-            StickyWindows.ExceptWith(invalids);
-        }
-        public IDisposable Iterate(IEnumerable<Task> asyncIterator)
-        {
-            if (asyncIterator == null) throw new ArgumentNullException("asyncIterator");
-
-            var enumerator = asyncIterator.GetEnumerator();
-            if (enumerator == null) throw new InvalidOperationException("Invalid enumerable - GetEnumerator returned null");
-
-            var source = new CancellationTokenSource();
-            var tcs = new TaskCompletionSource<object>();
-            tcs.Task.ContinueWith(_ => enumerator.Dispose(), TaskContinuationOptions.ExecuteSynchronously);
-
-            Action<Task> recursiveBody = null;
-            recursiveBody = delegate
-           {
-               try
-               {
-                   if (enumerator.MoveNext())
-                   {
-                       Task.Delay(TimeSpan.FromMilliseconds(15), source.Token)
-                                               .ContinueWith(_ =>
-                                               {
-                                                   enumerator.Current.Start();
-                                                   enumerator.Current.ContinueWith(recursiveBody, TaskContinuationOptions.ExecuteSynchronously);
-                                               }, TaskScheduler.FromCurrentSynchronizationContext());
-                   }
-                   else tcs.TrySetResult(null);
-               }
-               catch (Exception exc) { tcs.TrySetException(exc); }
-           };
-
-            recursiveBody(null);
-            return Disposable.Create(() => source.Cancel());
         }
 
-        public void Dispose()
-        {
-            VirtualDesktop.CurrentChanged -= this.VirtualDesktopOnCurrentChanged;
-        }
+        #endregion
     }
 
     public static class VirtualDesktopExtention
     {
+        #region Public Methods and Operators
+
         public static VirtualDesktop MoveSticky(this VirtualDesktop desktop)
         {
             StickyWindowsManager.Instance.MoveSticky(desktop.Id);
             return desktop;
         }
+
+        #endregion
     }
 }

--- a/source/SylphyHorn/Models/StickyWindowsManager.cs
+++ b/source/SylphyHorn/Models/StickyWindowsManager.cs
@@ -47,12 +47,12 @@ namespace SylphyHorn.Models
             if (StickyWindows.Contains(hWnd))
             {
                 StickyWindows.Remove(hWnd);
-                ToggleStickyWindowEvent.Invoke(this, title + ": Is remove from Pins windows");
+                ToggleStickyWindowEvent.Invoke(this, title + ": Is remove from pinned windows");
             }
             else
             {
                 StickyWindows.Add(hWnd);
-                ToggleStickyWindowEvent.Invoke(this, title + ": Is now Pin");
+                ToggleStickyWindowEvent.Invoke(this, title + ": Is now pinned");
             }
 
             Console.WriteLine(StickyWindows.ToString());
@@ -85,8 +85,8 @@ namespace SylphyHorn.Models
         }
 
         /*
-        * This create multiple task that will ve executed in sequence order. This is needed to prevent a concurrent probleme that
-        * occur when we move multiple windows of a save process ( multiple chrome window for exemple )
+        * This create multiple task that will be executed in sequence order. This is needed to prevent a concurrent probleme that
+        * occur when we move multiple windows of a same process ( multiple chrome window for exemple )
         */
         public IEnumerable<Task> CreateMovingTask(Guid id)
         {

--- a/source/SylphyHorn/SylphyHorn.csproj
+++ b/source/SylphyHorn/SylphyHorn.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Models\Helper.cs" />
     <Compile Include="Models\NotificationService.cs" />
     <Compile Include="Models\ShortcutKeyPressedEventArgs.cs" />
+    <Compile Include="Models\StickyWindowsManager.cs" />
     <Compile Include="ViewModels\NotificationWindowViewModel.cs" />
     <Compile Include="ViewModels\SettingsWindowViewModel.cs" />
     <Compile Include="Views\Controls\ClosingStoryboardBehavior.cs" />


### PR DESCRIPTION
Hi, great work by  the way!

I did a "pin window" or a "sticky window" feature. I noticed too late that you already made a branch that does just that, but the concept is the same: put the handles in a hashset and move them to the next virtual desktop each time.
The shortcut is "Ctrl + LWin + LAlt + P". I didn't added it to the shorcut menu yet.

**The problem** is when we try to move multiple window that comes from the same process. There seems to be a concurrent bug in the VDMHelper for this particular case. It may be isolated to chromium base applications has it doesn't work with multiple instance of chrome, electron.js,  atom.io or visual studio code,  etc

So the only workaround I found is to move them with a delay between them so the VDMHelper can finish whatever it is doing. It is not the perfect solution but for now it work. 

I really don't expect this to be merge has it is mainly to address this issue.
