### PR TITLE
Add feature to blur the notification/pin window.

### DIFF
--- a/source/SylphyHorn/Interop/NativeMethods.cs
+++ b/source/SylphyHorn/Interop/NativeMethods.cs
@@ -24,5 +24,8 @@ namespace SylphyHorn.Interop
 
 		[DllImport("user32.dll", CharSet = CharSet.Auto)]
 		public static extern int SystemParametersInfo(SystemParametersInfo uAction, int uParam, string lpvParam, SystemParametersInfoFlag fuWinIni);
+
+		[DllImport("user32.dll")]
+		internal static extern int SetWindowCompositionAttribute(IntPtr hwnd, ref WindowCompositionAttributeData data);
 	}
 }

--- a/source/SylphyHorn/Interop/WindowCompositionAttribute.cs
+++ b/source/SylphyHorn/Interop/WindowCompositionAttribute.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+// ReSharper disable InconsistentNaming
+
+namespace SylphyHorn.Interop
+{
+	internal enum AccentState
+	{
+		ACCENT_DISABLED = 1,
+		ACCENT_ENABLE_GRADIENT = 0,
+		ACCENT_ENABLE_TRANSPARENTGRADIENT = 2,
+		ACCENT_ENABLE_BLURBEHIND = 3,
+		ACCENT_INVALID_STATE = 4
+	}
+
+	[Flags]
+	internal enum AccentFlags
+	{
+		DrawLeftBorder = 0x20,
+		DrawTopBorder = 0x40,
+		DrawRightBorder = 0x80,
+		DrawBottomBorder = 0x100,
+		DrawAllBorders = (DrawLeftBorder | DrawTopBorder | DrawRightBorder | DrawBottomBorder)
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	internal struct AccentPolicy
+	{
+		public AccentState AccentState;
+		public AccentFlags AccentFlags;
+		public int GradientColor;
+		public int AnimationId;
+	}
+
+	internal enum WindowCompositionAttribute
+	{
+		WCA_UNDEFINED = 0,
+		WCA_NCRENDERING_ENABLED = 1,
+		WCA_NCRENDERING_POLICY = 2,
+		WCA_TRANSITIONS_FORCEDISABLED = 3,
+		WCA_ALLOW_NCPAINT = 4,
+		WCA_CAPTION_BUTTON_BOUNDS = 5,
+		WCA_NONCLIENT_RTL_LAYOUT = 6,
+		WCA_FORCE_ICONIC_REPRESENTATION = 7,
+		WCA_EXTENDED_FRAME_BOUNDS = 8,
+		WCA_HAS_ICONIC_BITMAP = 9,
+		WCA_THEME_ATTRIBUTES = 10,
+		WCA_NCRENDERING_EXILED = 11,
+		WCA_NCADORNMENTINFO = 12,
+		WCA_EXCLUDED_FROM_LIVEPREVIEW = 13,
+		WCA_VIDEO_OVERLAY_ACTIVE = 14,
+		WCA_FORCE_ACTIVEWINDOW_APPEARANCE = 15,
+		WCA_DISALLOW_PEEK = 16,
+		WCA_CLOAK = 17,
+		WCA_CLOAKED = 18,
+		WCA_ACCENT_POLICY = 19,
+		WCA_FREEZE_REPRESENTATION = 20,
+		WCA_EVER_UNCLOAKED = 21,
+		WCA_VISUAL_OWNER = 22,
+		WCA_LAST = 23
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	internal struct WindowCompositionAttributeData
+	{
+		public WindowCompositionAttribute Attribute;
+		public IntPtr Data;
+		public int SizeOfData;
+	}
+
+	internal class WindowCompositionHelper
+	{
+		internal static void SetWindowComposition(Window window, AccentState accentState, AccentFlags accentFlags)
+		{
+			var hwndSource = PresentationSource.FromVisual(window) as HwndSource;
+			if (hwndSource == null) return;
+
+			var accent = new AccentPolicy
+			{
+				AccentState = accentState,
+				AccentFlags = accentFlags,
+			};
+			var accentStructSize = Marshal.SizeOf(accent);
+			var accentPtr = Marshal.AllocHGlobal(accentStructSize);
+			Marshal.StructureToPtr(accent, accentPtr, false);
+
+			var data = new WindowCompositionAttributeData
+			{
+				Attribute = WindowCompositionAttribute.WCA_ACCENT_POLICY,
+				SizeOfData = accentStructSize,
+				Data = accentPtr,
+			};
+			NativeMethods.SetWindowCompositionAttribute(hwndSource.Handle, ref data);
+
+			Marshal.FreeHGlobal(accentPtr);
+		}
+	}
+}

--- a/source/SylphyHorn/SylphyHorn.csproj
+++ b/source/SylphyHorn/SylphyHorn.csproj
@@ -198,6 +198,7 @@
     <Compile Include="CommandLineArgs.cs" />
     <Compile Include="Interop\IconHelper.cs" />
     <Compile Include="Interop\Platform.cs" />
+    <Compile Include="Interop\WindowCompositionAttribute.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -206,6 +207,7 @@
     <Compile Include="Services\LoggingService.cs" />
     <Compile Include="Services\ResourceService.cs" />
     <Compile Include="Startup.cs" />
+    <Compile Include="UI\Controls\BlurWindow.cs" />
     <Compile Include="UI\Controls\Keytop.cs" />
     <Compile Include="UI\Controls\UnlockImageConverter.cs" />
     <Compile Include="UI\PinNotificationWindow.xaml.cs">

--- a/source/SylphyHorn/UI/Controls/BlurWindow.cs
+++ b/source/SylphyHorn/UI/Controls/BlurWindow.cs
@@ -1,0 +1,66 @@
+﻿using SylphyHorn.Interop;
+using System;
+using System.Windows;
+
+namespace SylphyHorn.UI.Controls
+{
+	public class BlurWindow : Window
+	{
+		private bool _isBlured = false;
+
+		#region IsBlured 依存関係プロパティ
+
+		public bool IsBlured
+		{
+			get { return (bool)this.GetValue(IsBluredProperty); }
+			set { this.SetValue(IsBluredProperty, value); }
+		}
+		public static readonly DependencyProperty IsBluredProperty =
+			DependencyProperty.Register("IsBlured", typeof(bool), typeof(BlurWindow), new UIPropertyMetadata(false, IsBluredChangedCallback));
+
+		private static void IsBluredChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			var window = d as BlurWindow;
+			if (window == null) return;
+
+			window.ChangeIsBlured((bool)e.NewValue);
+		}
+
+		#endregion
+
+		protected override void OnSourceInitialized(EventArgs e)
+		{
+			this.ChangeIsBlured(this.IsBlured);
+
+			base.OnSourceInitialized(e);
+		}
+
+		private void ChangeIsBlured(bool blured)
+		{
+			if (!this.IsInitialized) return;
+
+			var highContrast = SystemParameters.HighContrast;
+			var transparency = this.AllowsTransparency;
+			if (!highContrast && transparency && blured && !this._isBlured)
+			{
+				this.EnableBlur();
+				this._isBlured = true;
+			}
+			else if ((!transparency || !blured) && this._isBlured)
+			{
+				this.DisableBlur();
+				this._isBlured = false;
+			}
+		}
+
+		private void EnableBlur()
+		{
+			WindowCompositionHelper.SetWindowComposition(this, AccentState.ACCENT_ENABLE_BLURBEHIND, AccentFlags.DrawAllBorders);
+		}
+
+		private void DisableBlur()
+		{
+			WindowCompositionHelper.SetWindowComposition(this, AccentState.ACCENT_DISABLED, 0);
+		}
+	}
+}

--- a/source/SylphyHorn/UI/NotificationWindow.xaml
+++ b/source/SylphyHorn/UI/NotificationWindow.xaml
@@ -1,26 +1,27 @@
-﻿<Window x:Class="SylphyHorn.UI.NotificationWindow"
-		xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-		xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-		xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-		xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-		xmlns:livet="http://schemas.livet-mvvm.net/2011/wpf"
-		xmlns:bindings="clr-namespace:SylphyHorn.UI.Bindings"
-		xmlns:controls="clr-namespace:SylphyHorn.UI.Controls"
-		mc:Ignorable="d"
-		d:DataContext="{d:DesignInstance bindings:NotificationWindowViewModel}"
-		Title="{Binding Title}"
-		Width="600"
-		Height="100"
-		ResizeMode="NoResize"
-		WindowStyle="None"
-		WindowStartupLocation="CenterScreen"
-		Topmost="True"
-		ShowInTaskbar="False"
-		AllowsTransparency="True"
-		SnapsToDevicePixels="True"
-		Background="Transparent"
-		Foreground="{DynamicResource ActiveForegroundBrushKey}">
+﻿<controls:BlurWindow x:Class="SylphyHorn.UI.NotificationWindow"
+					 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+					 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+					 xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+					 xmlns:livet="http://schemas.livet-mvvm.net/2011/wpf"
+					 xmlns:bindings="clr-namespace:SylphyHorn.UI.Bindings"
+					 xmlns:controls="clr-namespace:SylphyHorn.UI.Controls"
+					 mc:Ignorable="d"
+					 d:DataContext="{d:DesignInstance bindings:NotificationWindowViewModel}"
+					 Title="{Binding Title}"
+					 Width="600"
+					 Height="100"
+					 ResizeMode="NoResize"
+					 WindowStyle="None"
+					 WindowStartupLocation="CenterScreen"
+					 Topmost="True"
+					 ShowInTaskbar="False"
+					 AllowsTransparency="True"
+					 IsBlured="True"
+					 SnapsToDevicePixels="True"
+					 Background="Transparent"
+					 Foreground="{DynamicResource ActiveForegroundBrushKey}">
 	<Window.Resources>
 		<Storyboard x:Key="FadeIn">
 			<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)"
@@ -104,4 +105,4 @@
 					   FontSize="42" />
 		</DockPanel>
 	</Grid>
-</Window>
+</controls:BlurWindow>

--- a/source/SylphyHorn/UI/PinNotificationWindow.xaml
+++ b/source/SylphyHorn/UI/PinNotificationWindow.xaml
@@ -1,26 +1,27 @@
-﻿<Window x:Class="SylphyHorn.UI.PinNotificationWindow"
-		xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-		xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-		xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-		xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-		xmlns:livet="http://schemas.livet-mvvm.net/2011/wpf"
-		xmlns:bindings="clr-namespace:SylphyHorn.UI.Bindings"
-		xmlns:controls="clr-namespace:SylphyHorn.UI.Controls"
-		mc:Ignorable="d"
-		d:DataContext="{d:DesignInstance bindings:NotificationWindowViewModel}"
-		Title="{Binding Title}"
-		Width="400"
-		Height="100"
-		ResizeMode="NoResize"
-		WindowStyle="None"
-		WindowStartupLocation="CenterScreen"
-		Topmost="True"
-		ShowInTaskbar="False"
-		AllowsTransparency="True"
-		SnapsToDevicePixels="True"
-		Background="Transparent"
-		Foreground="{DynamicResource ActiveForegroundBrushKey}">
+﻿<controls:BlurWindow x:Class="SylphyHorn.UI.PinNotificationWindow"
+					 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+					 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+					 xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+					 xmlns:livet="http://schemas.livet-mvvm.net/2011/wpf"
+					 xmlns:bindings="clr-namespace:SylphyHorn.UI.Bindings"
+					 xmlns:controls="clr-namespace:SylphyHorn.UI.Controls"
+					 mc:Ignorable="d"
+					 d:DataContext="{d:DesignInstance bindings:NotificationWindowViewModel}"
+					 Title="{Binding Title}"
+					 Width="400"
+					 Height="100"
+					 ResizeMode="NoResize"
+					 WindowStyle="None"
+					 WindowStartupLocation="CenterScreen"
+					 Topmost="True"
+					 ShowInTaskbar="False"
+					 AllowsTransparency="True"
+					 IsBlured="True"
+					 SnapsToDevicePixels="True"
+					 Background="Transparent"
+					 Foreground="{DynamicResource ActiveForegroundBrushKey}">
 	<Window.Resources>
 		<Storyboard x:Key="FadeIn">
 			<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)"
@@ -104,4 +105,4 @@
 					   FontSize="32" />
 		</DockPanel>
 	</Grid>
-</Window>
+</controls:BlurWindow>


### PR DESCRIPTION
This patch is to blur notification/pin window. This change is to increase affinity to Windows UI by adding blur effect.

### Known issue

- Notification window is sometimes blurred before the contents is not rendered.

### Sample screenshot

#### Before change 

<img width="487" alt="blur-sample0-original" src="https://cloud.githubusercontent.com/assets/901816/21290699/f17ac7c6-c507-11e6-81c1-3f328170e1e4.png">

#### After change

<img width="486" alt="blur-sample1" src="https://cloud.githubusercontent.com/assets/901816/21290678/3fc9b622-c507-11e6-9891-c1692f6f9970.png">
<img width="324" alt="blur-sample2" src="https://cloud.githubusercontent.com/assets/901816/21290679/4269432a-c507-11e6-9f25-1ae0b14aebeb.png">

Apply “Dark” theme:

<img width="481" alt="blur-sample5" src="https://cloud.githubusercontent.com/assets/901816/21290714/3ea06934-c508-11e6-84f5-0ce06b27d353.png">

Finally, annotate in Japanese. 本コミットには境界線ありのバージョンで記述していますが，`AccentPolicy` の `AccentFlags` を 0 にすることにより，境界線を表示しないことも可能です。そのときのスクリーンショットも掲載しておきます。

<img width="470" alt="blur-sample3" src="https://cloud.githubusercontent.com/assets/901816/21290680/48a31752-c507-11e6-89a5-e00bbb55f2cf.png">
