### PR TITLE
Add feature to close current virtual desktop.

### DIFF
--- a/source/SylphyHorn.Core/Serialization/ShortcutKeySettings.cs
+++ b/source/SylphyHorn.Core/Serialization/ShortcutKeySettings.cs
@@ -31,6 +31,8 @@ namespace SylphyHorn.Serialization
 
 		public ShortcutkeyProperty SwitchToRight => this.Cache(key => new ShortcutkeyProperty(key, this._provider, SwitchToRightDefaultValue));
 
+		public ShortcutkeyProperty Close => this.Cache(key => new ShortcutkeyProperty(key, this._provider));
+
 		public ShortcutkeyProperty Pin => this.Cache(key => new ShortcutkeyProperty(key, this._provider));
 
 		public ShortcutkeyProperty Unpin => this.Cache(key => new ShortcutkeyProperty(key, this._provider));

--- a/source/SylphyHorn.Core/Serialization/ShortcutKeySettings.cs
+++ b/source/SylphyHorn.Core/Serialization/ShortcutKeySettings.cs
@@ -31,7 +31,9 @@ namespace SylphyHorn.Serialization
 
 		public ShortcutkeyProperty SwitchToRight => this.Cache(key => new ShortcutkeyProperty(key, this._provider, SwitchToRightDefaultValue));
 
-		public ShortcutkeyProperty Close => this.Cache(key => new ShortcutkeyProperty(key, this._provider));
+		public ShortcutkeyProperty CloseAndSwitchLeft => this.Cache(key => new ShortcutkeyProperty(key, this._provider));
+
+		public ShortcutkeyProperty CloseAndSwitchRight => this.Cache(key => new ShortcutkeyProperty(key, this._provider));
 
 		public ShortcutkeyProperty Pin => this.Cache(key => new ShortcutkeyProperty(key, this._provider));
 

--- a/source/SylphyHorn/ApplicationPreparation.cs
+++ b/source/SylphyHorn/ApplicationPreparation.cs
@@ -64,6 +64,10 @@ namespace SylphyHorn
 				.AddTo(this._application);
 
 			this._application.HookService
+				.Register(() => settings.Close.ToShortcutKey(), _ => VirtualDesktopService.CloseCurrent())
+				.AddTo(this._application);
+
+			this._application.HookService
 				.Register(() => settings.Pin.ToShortcutKey(), hWnd => hWnd.Pin())
 				.AddTo(this._application);
 

--- a/source/SylphyHorn/ApplicationPreparation.cs
+++ b/source/SylphyHorn/ApplicationPreparation.cs
@@ -64,7 +64,11 @@ namespace SylphyHorn
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.Close.ToShortcutKey(), _ => VirtualDesktopService.CloseCurrent())
+				.Register(() => settings.CloseAndSwitchLeft.ToShortcutKey(), _ => VirtualDesktopService.CloseAndSwitchLeft())
+				.AddTo(this._application);
+
+			this._application.HookService
+				.Register(() => settings.CloseAndSwitchRight.ToShortcutKey(), _ => VirtualDesktopService.CloseAndSwitchRight())
 				.AddTo(this._application);
 
 			this._application.HookService

--- a/source/SylphyHorn/Properties/Resources.Designer.cs
+++ b/source/SylphyHorn/Properties/Resources.Designer.cs
@@ -131,6 +131,25 @@ namespace SylphyHorn.Properties {
                 return ResourceManager.GetString("Settings_Background_SourceImageFolder", resourceCulture);
             }
         }
+
+
+        /// <summary>
+        ///   Looks up a localized string similar to Close desktop.
+        /// </summary>
+        public static string Settings_CloseDesktop {
+            get {
+                return ResourceManager.GetString("Settings_CloseDesktop", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Close:.
+        /// </summary>
+        public static string Settings_CloseDesktop_Close {
+            get {
+                return ResourceManager.GetString("Settings_CloseDesktop_Close", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Desktop switching.

--- a/source/SylphyHorn/Properties/Resources.Designer.cs
+++ b/source/SylphyHorn/Properties/Resources.Designer.cs
@@ -143,11 +143,29 @@ namespace SylphyHorn.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Close:.
+        ///   Looks up a localized string similar to Close and switch left:.
         /// </summary>
-        public static string Settings_CloseDesktop_Close {
+        public static string Settings_CloseDesktop_CloseAndSwitchLeft {
             get {
-                return ResourceManager.GetString("Settings_CloseDesktop_Close", resourceCulture);
+                return ResourceManager.GetString("Settings_CloseDesktop_CloseAndSwitchLeft", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to provided by Windows with Ctrl+Win+F4.
+        /// </summary>
+        public static string Settings_CloseDesktop_CloseAndSwitchLeft_Note {
+            get {
+                return ResourceManager.GetString("Settings_CloseDesktop_CloseAndSwitchLeft_Note", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Close and switch right:.
+        /// </summary>
+        public static string Settings_CloseDesktop_CloseAndSwitchRight {
+            get {
+                return ResourceManager.GetString("Settings_CloseDesktop_CloseAndSwitchRight", resourceCulture);
             }
         }
         

--- a/source/SylphyHorn/Properties/Resources.ja.resx
+++ b/source/SylphyHorn/Properties/Resources.ja.resx
@@ -141,6 +141,12 @@
   <data name="Settings_Background_SourceImageFolder" xml:space="preserve">
     <value>画像フォルダー パス</value>
   </data>
+  <data name="Settings_CloseDesktop" xml:space="preserve">
+    <value>仮想デスクトップを閉じる</value>
+  </data>
+  <data name="Settings_CloseDesktop_Close" xml:space="preserve">
+    <value>閉じる:</value>
+  </data>
   <data name="Settings_DesktopSwitching" xml:space="preserve">
     <value>デスクトップ切り替え</value>
   </data>

--- a/source/SylphyHorn/Properties/Resources.ja.resx
+++ b/source/SylphyHorn/Properties/Resources.ja.resx
@@ -144,8 +144,14 @@
   <data name="Settings_CloseDesktop" xml:space="preserve">
     <value>仮想デスクトップを閉じる</value>
   </data>
-  <data name="Settings_CloseDesktop_Close" xml:space="preserve">
-    <value>閉じる:</value>
+  <data name="Settings_CloseDesktop_CloseAndSwitchLeft" xml:space="preserve">
+    <value>閉じて左へ切り替え:</value>
+  </data>
+  <data name="Settings_CloseDesktop_CloseAndSwitchLeft_Note" xml:space="preserve">
+    <value>Windows が Ctrl+Win+F4 で提供</value>
+  </data>
+  <data name="Settings_CloseDesktop_CloseAndSwitchRight" xml:space="preserve">
+    <value>閉じて右へ切り替え:</value>
   </data>
   <data name="Settings_DesktopSwitching" xml:space="preserve">
     <value>デスクトップ切り替え</value>

--- a/source/SylphyHorn/Properties/Resources.resx
+++ b/source/SylphyHorn/Properties/Resources.resx
@@ -141,6 +141,12 @@
   <data name="Settings_Background_SourceImageFolder" xml:space="preserve">
     <value>Source image folder path</value>
   </data>
+  <data name="Settings_CloseDesktop" xml:space="preserve">
+    <value>Close desktop</value>
+  </data>
+  <data name="Settings_CloseDesktop_Close" xml:space="preserve">
+    <value>Close:</value>
+  </data>
   <data name="Settings_DesktopSwitching" xml:space="preserve">
     <value>Desktop switching</value>
   </data>

--- a/source/SylphyHorn/Properties/Resources.resx
+++ b/source/SylphyHorn/Properties/Resources.resx
@@ -144,8 +144,14 @@
   <data name="Settings_CloseDesktop" xml:space="preserve">
     <value>Close desktop</value>
   </data>
-  <data name="Settings_CloseDesktop_Close" xml:space="preserve">
-    <value>Close:</value>
+  <data name="Settings_CloseDesktop_CloseAndSwitchLeft" xml:space="preserve">
+    <value>Close and switch left:</value>
+  </data>
+  <data name="Settings_CloseDesktop_CloseAndSwitchLeft_Note" xml:space="preserve">
+    <value>provided by Windows with Ctrl+Win+F4</value>
+  </data>
+  <data name="Settings_CloseDesktop_CloseAndSwitchRight" xml:space="preserve">
+    <value>Close and switch right:</value>
   </data>
   <data name="Settings_DesktopSwitching" xml:space="preserve">
     <value>Desktop switching</value>

--- a/source/SylphyHorn/Services/VirtualDesktopService.cs
+++ b/source/SylphyHorn/Services/VirtualDesktopService.cs
@@ -101,15 +101,26 @@ namespace SylphyHorn.Services
 
 		#region Close
 
-		public static void CloseCurrent()
+		public static void CloseAndSwitchLeft()
 		{
 			var current = VirtualDesktop.Current;
 			var desktops = VirtualDesktop.GetDesktops();
 			
 			if (desktops.Length > 1)
 			{
-				var future = GetLeft() ?? GetRight();
-				future.Switch();
+				GetLeft()?.Switch();
+				current.Remove();
+			}
+		}
+
+		public static void CloseAndSwitchRight()
+		{
+			var current = VirtualDesktop.Current;
+			var desktops = VirtualDesktop.GetDesktops();
+
+			if (desktops.Length > 1)
+			{
+				GetRight()?.Switch();
 				current.Remove();
 			}
 		}

--- a/source/SylphyHorn/Services/VirtualDesktopService.cs
+++ b/source/SylphyHorn/Services/VirtualDesktopService.cs
@@ -99,6 +99,23 @@ namespace SylphyHorn.Services
 
 		#endregion
 
+		#region Close
+
+		public static void CloseCurrent()
+		{
+			var current = VirtualDesktop.Current;
+			var desktops = VirtualDesktop.GetDesktops();
+			
+			if (desktops.Length > 1)
+			{
+				var future = GetLeft() ?? GetRight();
+				future.Switch();
+				current.Remove();
+			}
+		}
+
+		#endregion
+
 		#region Pin / Unpin
 
 		public static event EventHandler<WindowPinnedEventArgs> WindowPinned;

--- a/source/SylphyHorn/UI/SettingsWindow.xaml
+++ b/source/SylphyHorn/UI/SettingsWindow.xaml
@@ -335,11 +335,14 @@
 								<ColumnDefinition Width="*" />
 							</Grid.ColumnDefinitions>
 							<UniformGrid Columns="1">
-								<TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_CloseDesktop_Close}" />
+								<TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_CloseDesktop_CloseAndSwitchLeft}" />
+								<TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_CloseDesktop_CloseAndSwitchRight}" />
 							</UniformGrid>
 							<UniformGrid Grid.Column="2"
 										 Columns="1">
-								<controls:ShortcutKeyBox Current="{Binding Source={x:Static serialization:Settings.ShortcutKey}, Path=Close.Value, Mode=TwoWay}" />
+								<controls:ShortcutKeyBox Current="{Binding Source={x:Static serialization:Settings.ShortcutKey}, Path=CloseAndSwitchLeft.Value, Mode=TwoWay}"
+														 Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_CloseDesktop_CloseAndSwitchLeft_Note, StringFormat=' ({0})', Mode=OneWay}" />
+								<controls:ShortcutKeyBox Current="{Binding Source={x:Static serialization:Settings.ShortcutKey}, Path=CloseAndSwitchRight.Value, Mode=TwoWay}" />
 							</UniformGrid>
 						</Grid>
 					</StackPanel>

--- a/source/SylphyHorn/UI/SettingsWindow.xaml
+++ b/source/SylphyHorn/UI/SettingsWindow.xaml
@@ -323,6 +323,25 @@
 								<controls:ShortcutKeyBox Current="{Binding Source={x:Static serialization:Settings.ShortcutKey}, Path=MoveNewAndSwitch.Value, Mode=TwoWay}" />
 							</UniformGrid>
 						</Grid>
+						<Border Height="16" />
+
+						<TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_CloseDesktop}"
+								   Style="{DynamicResource HeaderStyleKey}" />
+						<Grid Margin="8,0,0,0">
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto"
+												  SharedSizeGroup="KeyHeader" />
+								<ColumnDefinition Width="8" />
+								<ColumnDefinition Width="*" />
+							</Grid.ColumnDefinitions>
+							<UniformGrid Columns="1">
+								<TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_CloseDesktop_Close}" />
+							</UniformGrid>
+							<UniformGrid Grid.Column="2"
+										 Columns="1">
+								<controls:ShortcutKeyBox Current="{Binding Source={x:Static serialization:Settings.ShortcutKey}, Path=Close.Value, Mode=TwoWay}" />
+							</UniformGrid>
+						</Grid>
 					</StackPanel>
 				</ScrollViewer>
 			</TabItem>


### PR DESCRIPTION
### Sample screenshot

Settings pane

![image](https://cloud.githubusercontent.com/assets/901816/21449559/c4e9fcbc-c931-11e6-8cf1-8c97a73a901a.png)

---

PS

Its shortcut key to close current virtual desktop is provided by Windows: `Win+Ctrl+F4`  
https://support.microsoft.com/en-us/help/12445/windows-keyboard-shortcuts

But, users want to override default key.
https://twitter.com/ChiiAyano/status/812201130776109056

I think two surfaces methods to implement this function.

1) leave OS default shortcut key
2) disable OS default shortcut key

What do you think about?