### PR TITLE
Updates to support smooth switching (animated switching) + Configurable Theme and Accent Colors

### DIFF
--- a/source/SylphyHorn.Core/Serialization/GeneralSettings.cs
+++ b/source/SylphyHorn.Core/Serialization/GeneralSettings.cs
@@ -17,7 +17,9 @@ namespace SylphyHorn.Serialization
 
 		public SerializableProperty<bool> LoopDesktop => this.Cache(key => new SerializableProperty<bool>(key, this._provider));
 
-		public SerializableProperty<bool> NotificationWhenSwitchedDesktop => this.Cache(key => new SerializableProperty<bool>(key, this._provider, true));
+        public SerializableProperty<bool> SmoothSwitch => this.Cache(key => new SerializableProperty<bool>(key, this._provider));
+
+        public SerializableProperty<bool> NotificationWhenSwitchedDesktop => this.Cache(key => new SerializableProperty<bool>(key, this._provider, true));
 
 		public SerializableProperty<int> NotificationDuration => this.Cache(key => new SerializableProperty<int>(key, this._provider, 2500));
 

--- a/source/SylphyHorn.Core/Serialization/GeneralSettings.cs
+++ b/source/SylphyHorn.Core/Serialization/GeneralSettings.cs
@@ -34,5 +34,9 @@ namespace SylphyHorn.Serialization
 		public SerializableProperty<bool> FirstTime => this.Cache(key => new SerializableProperty<bool>(key, this._provider, true));
 
 		public SerializableProperty<string> Culture => this.Cache(key => new SerializableProperty<string>(key, this._provider));
-	}
+
+        public SerializableProperty<string> Theme => this.Cache(key => new SerializableProperty<string>(key, this._provider));
+
+        public SerializableProperty<string> Accent => this.Cache(key => new SerializableProperty<string>(key, this._provider));
+    }
 }

--- a/source/SylphyHorn/Application.xaml
+++ b/source/SylphyHorn/Application.xaml
@@ -9,8 +9,8 @@
 				<ResourceDictionary Source="pack://application:,,,/MetroRadiance;component/Styles/Controls.xaml" />
 				<ResourceDictionary Source="pack://application:,,,/MetroRadiance;component/Styles/Icons.xaml" />
 				<ResourceDictionary Source="pack://application:,,,/MetroRadiance;component/Themes/Light.xaml" />
-				<ResourceDictionary Source="pack://application:,,,/MetroRadiance;component/Themes/Accents/Blue.xaml" />
 				<ResourceDictionary Source="pack://application:,,,/MetroTrilithon.Desktop;component/Styles/Controls.xaml" />
+				<ResourceDictionary Source="pack://application:,,,/MetroRadiance;component/Themes/Accents/Blue.xaml" />
 				
 				<ResourceDictionary Source="pack://application:,,,/SylphyHorn;component/Styles/Controls.xaml" />
 			</ResourceDictionary.MergedDictionaries>

--- a/source/SylphyHorn/Application.xaml.cs
+++ b/source/SylphyHorn/Application.xaml.cs
@@ -46,7 +46,7 @@ namespace SylphyHorn
 			}
 
 #if !DEBUG
-			var appInstance = new MetroTrilithon.Desktop.ApplicationInstance().AddTo(this);
+            var appInstance = new MetroTrilithon.Desktop.ApplicationInstance().AddTo(this);
 			if (appInstance.IsFirst || Args.Restarted.HasValue)
 #endif
 			{

--- a/source/SylphyHorn/Application.xaml.cs
+++ b/source/SylphyHorn/Application.xaml.cs
@@ -36,6 +36,21 @@ namespace SylphyHorn
 
 		internal UwpInteropService InteropService { get; private set; }
 
+	    internal Theme GetTheme(string themeName)
+	    {
+	        return themeName == Theme.Dark.ToString() ? Theme.Dark :
+	            themeName == Theme.Light.ToString() ? Theme.Light :
+	                Theme.Windows;
+	    }
+
+	    internal Accent GetAccent(string accentName)
+	    {
+	        return accentName == Accent.Blue.ToString() ? Accent.Blue :
+	            accentName == Accent.Orange.ToString() ? Accent.Orange :
+	                accentName == Accent.Purple.ToString() ? Accent.Purple :
+	                    Accent.Windows;
+	    }
+
 		protected override void OnStartup(StartupEventArgs e)
 		{
 			Args = new CommandLineArgs(e.Args);
@@ -59,8 +74,11 @@ namespace SylphyHorn
 
 					LocalSettingsProvider.Instance.LoadAsync().Wait();
 
-					Settings.General.Culture.Subscribe(x => ResourceService.Current.ChangeCulture(x)).AddTo(this);
-					ThemeService.Current.Register(this, Theme.Windows, Accent.Windows);
+                    Settings.General.Culture.Subscribe(x => ResourceService.Current.ChangeCulture(x)).AddTo(this);
+				    Settings.General.Theme.Subscribe(x =>
+				        ThemeService.Current.Register(this, this.GetTheme(x), this.GetAccent(Settings.General.Accent)));
+				    Settings.General.Accent.Subscribe(x =>
+                        ThemeService.Current.Register(this, this.GetTheme(Settings.General.Theme), this.GetAccent(x)));
 
 					this.HookService = new HookService().AddTo(this);
 					this.InteropService = new UwpInteropService(this.HookService, Settings.General).AddTo(this);

--- a/source/SylphyHorn/ApplicationPreparation.cs
+++ b/source/SylphyHorn/ApplicationPreparation.cs
@@ -26,73 +26,80 @@ namespace SylphyHorn
 			var settings = Settings.ShortcutKey;
 
 			this._application.HookService
-				.Register(()=>settings.MoveLeft.ToShortcutKey(), hWnd => hWnd.MoveToLeft())
+				.Register(()=>settings.MoveLeft.ToShortcutKey(), (hWnd, keyDetector) => hWnd.MoveToLeft())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.MoveLeftAndSwitch.ToShortcutKey(), hWnd => hWnd.MoveToLeft()?.Switch())
+				.Register(() => settings.MoveLeftAndSwitch.ToShortcutKey(), (hWnd, keyDetector) =>
+                    hWnd.MoveToLeft()?.Switch(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()))
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.MoveRight.ToShortcutKey(), hWnd => hWnd.MoveToRight())
+				.Register(() => settings.MoveRight.ToShortcutKey(), (hWnd, keyDetector) => hWnd.MoveToRight())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.MoveRightAndSwitch.ToShortcutKey(), hWnd => hWnd.MoveToRight()?.Switch())
+				.Register(() => settings.MoveRightAndSwitch.ToShortcutKey(), (hWnd, keyDetector) =>
+                    hWnd.MoveToRight()?.Switch(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()))
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.MoveNew.ToShortcutKey(), hWnd => hWnd.MoveToNew())
+				.Register(() => settings.MoveNew.ToShortcutKey(), (hWnd, keyDetector) => hWnd.MoveToNew())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.MoveNewAndSwitch.ToShortcutKey(), hWnd => hWnd.MoveToNew()?.Switch())
+				.Register(() => settings.MoveNewAndSwitch.ToShortcutKey(), (hWnd, keyDetector) =>
+                    hWnd.MoveToNew()?.Switch(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()))
 				.AddTo(this._application);
 
 			this._application.HookService
 				.Register(
 					() => settings.SwitchToLeft.ToShortcutKey(),
-					_ => VirtualDesktopService.GetLeft()?.Switch(),
+                    (hWnd, keyDetector) =>
+                        VirtualDesktopService.GetLeft()?.Switch(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()),
 					() => Settings.General.OverrideWindowsDefaultKeyCombination || Settings.General.ChangeBackgroundEachDesktop)
 				.AddTo(this._application);
 
 			this._application.HookService
 				.Register(
 					() => settings.SwitchToRight.ToShortcutKey(),
-					_ => VirtualDesktopService.GetRight()?.Switch(),
+                    (hWnd, keyDetector) =>
+                        VirtualDesktopService.GetRight()?.Switch(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()),
 					() => Settings.General.OverrideWindowsDefaultKeyCombination || Settings.General.ChangeBackgroundEachDesktop)
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.CloseAndSwitchLeft.ToShortcutKey(), _ => VirtualDesktopService.CloseAndSwitchLeft())
+				.Register(() => settings.CloseAndSwitchLeft.ToShortcutKey(), (hWnd, keyDetector) =>
+                    VirtualDesktopService.CloseAndSwitchLeft(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()))
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.CloseAndSwitchRight.ToShortcutKey(), _ => VirtualDesktopService.CloseAndSwitchRight())
+				.Register(() => settings.CloseAndSwitchRight.ToShortcutKey(), (hWnd, keyDetector) =>
+                    VirtualDesktopService.CloseAndSwitchRight(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()))
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.Pin.ToShortcutKey(), hWnd => hWnd.Pin())
+				.Register(() => settings.Pin.ToShortcutKey(), (hWnd, keyDetector) => hWnd.Pin())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.Unpin.ToShortcutKey(), hWnd => hWnd.Unpin())
+				.Register(() => settings.Unpin.ToShortcutKey(), (hWnd, keyDetector) => hWnd.Unpin())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.TogglePin.ToShortcutKey(), hWnd => hWnd.TogglePin())
+				.Register(() => settings.TogglePin.ToShortcutKey(), (hWnd, keyDetector) => hWnd.TogglePin())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.PinApp.ToShortcutKey(), hWnd => hWnd.PinApp())
+				.Register(() => settings.PinApp.ToShortcutKey(), (hWnd, keyDetector) => hWnd.PinApp())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.UnpinApp.ToShortcutKey(), hWnd => hWnd.UnpinApp())
+				.Register(() => settings.UnpinApp.ToShortcutKey(), (hWnd, keyDetector) => hWnd.UnpinApp())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.TogglePinApp.ToShortcutKey(), hWnd => hWnd.TogglePinApp())
+				.Register(() => settings.TogglePinApp.ToShortcutKey(), (hWnd, keyDetector) => hWnd.TogglePinApp())
 				.AddTo(this._application);
 		}
 

--- a/source/SylphyHorn/ApplicationPreparation.cs
+++ b/source/SylphyHorn/ApplicationPreparation.cs
@@ -26,80 +26,82 @@ namespace SylphyHorn
 			var settings = Settings.ShortcutKey;
 
 			this._application.HookService
-				.Register(()=>settings.MoveLeft.ToShortcutKey(), (hWnd, keyDetector) => hWnd.MoveToLeft())
+				.Register(()=>settings.MoveLeft.ToShortcutKey(), (hWnd, keyDetector, key) => hWnd.MoveToLeft())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.MoveLeftAndSwitch.ToShortcutKey(), (hWnd, keyDetector) =>
-                    hWnd.MoveToLeft()?.Switch(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()))
+				.Register(() => settings.MoveLeftAndSwitch.ToShortcutKey(), (hWnd, keyDetector, key) =>
+                    hWnd.MoveToLeft()?.Switch(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey(), null))
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.MoveRight.ToShortcutKey(), (hWnd, keyDetector) => hWnd.MoveToRight())
+				.Register(() => settings.MoveRight.ToShortcutKey(), (hWnd, keyDetector, key) => hWnd.MoveToRight())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.MoveRightAndSwitch.ToShortcutKey(), (hWnd, keyDetector) =>
-                    hWnd.MoveToRight()?.Switch(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()))
+				.Register(() => settings.MoveRightAndSwitch.ToShortcutKey(), (hWnd, keyDetector, key) =>
+                    hWnd.MoveToRight()?.Switch(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey(), null))
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.MoveNew.ToShortcutKey(), (hWnd, keyDetector) => hWnd.MoveToNew())
+				.Register(() => settings.MoveNew.ToShortcutKey(), (hWnd, keyDetector, key) => hWnd.MoveToNew())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.MoveNewAndSwitch.ToShortcutKey(), (hWnd, keyDetector) =>
-                    hWnd.MoveToNew()?.Switch(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()))
+				.Register(() => settings.MoveNewAndSwitch.ToShortcutKey(), (hWnd, keyDetector, key) =>
+                    hWnd.MoveToNew()?.Switch(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey(), null))
 				.AddTo(this._application);
 
 			this._application.HookService
 				.Register(
 					() => settings.SwitchToLeft.ToShortcutKey(),
-                    (hWnd, keyDetector) =>
-                        VirtualDesktopService.GetLeft()?.Switch(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()),
-					() => Settings.General.OverrideWindowsDefaultKeyCombination || Settings.General.ChangeBackgroundEachDesktop)
+                    (hWnd, keyDetector, key) =>
+                        VirtualDesktopService.GetLeft()?.Switch(IntPtr.Zero, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey(), key),
+					() => Settings.General.OverrideWindowsDefaultKeyCombination || Settings.General.ChangeBackgroundEachDesktop,
+                    () => false)
 				.AddTo(this._application);
 
 			this._application.HookService
 				.Register(
 					() => settings.SwitchToRight.ToShortcutKey(),
-                    (hWnd, keyDetector) =>
-                        VirtualDesktopService.GetRight()?.Switch(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()),
-					() => Settings.General.OverrideWindowsDefaultKeyCombination || Settings.General.ChangeBackgroundEachDesktop)
+                    (hWnd, keyDetector, key) =>
+                        VirtualDesktopService.GetRight()?.Switch(IntPtr.Zero, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey(), key),
+					() => Settings.General.OverrideWindowsDefaultKeyCombination || Settings.General.ChangeBackgroundEachDesktop,
+                    () => false)
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.CloseAndSwitchLeft.ToShortcutKey(), (hWnd, keyDetector) =>
-                    VirtualDesktopService.CloseAndSwitchLeft(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()))
+				.Register(() => settings.CloseAndSwitchLeft.ToShortcutKey(), (hWnd, keyDetector, key) =>
+                    VirtualDesktopService.CloseAndSwitchLeft(keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()))
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.CloseAndSwitchRight.ToShortcutKey(), (hWnd, keyDetector) =>
-                    VirtualDesktopService.CloseAndSwitchRight(hWnd, keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()))
+				.Register(() => settings.CloseAndSwitchRight.ToShortcutKey(), (hWnd, keyDetector, key) =>
+                    VirtualDesktopService.CloseAndSwitchRight(keyDetector, Settings.General.SmoothSwitch, settings.SwitchToLeft.ToShortcutKey(), settings.SwitchToRight.ToShortcutKey()))
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.Pin.ToShortcutKey(), (hWnd, keyDetector) => hWnd.Pin())
+				.Register(() => settings.Pin.ToShortcutKey(), (hWnd, keyDetector, key) => hWnd.Pin())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.Unpin.ToShortcutKey(), (hWnd, keyDetector) => hWnd.Unpin())
+				.Register(() => settings.Unpin.ToShortcutKey(), (hWnd, keyDetector, key) => hWnd.Unpin())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.TogglePin.ToShortcutKey(), (hWnd, keyDetector) => hWnd.TogglePin())
+				.Register(() => settings.TogglePin.ToShortcutKey(), (hWnd, keyDetector, key) => hWnd.TogglePin())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.PinApp.ToShortcutKey(), (hWnd, keyDetector) => hWnd.PinApp())
+				.Register(() => settings.PinApp.ToShortcutKey(), (hWnd, keyDetector, key) => hWnd.PinApp())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.UnpinApp.ToShortcutKey(), (hWnd, keyDetector) => hWnd.UnpinApp())
+				.Register(() => settings.UnpinApp.ToShortcutKey(), (hWnd, keyDetector, key) => hWnd.UnpinApp())
 				.AddTo(this._application);
 
 			this._application.HookService
-				.Register(() => settings.TogglePinApp.ToShortcutKey(), (hWnd, keyDetector) => hWnd.TogglePinApp())
+				.Register(() => settings.TogglePinApp.ToShortcutKey(), (hWnd, keyDetector, key) => hWnd.TogglePinApp())
 				.AddTo(this._application);
 		}
 

--- a/source/SylphyHorn/Properties/Resources.Designer.cs
+++ b/source/SylphyHorn/Properties/Resources.Designer.cs
@@ -185,24 +185,22 @@ namespace SylphyHorn.Properties {
                 return ResourceManager.GetString("Settings_DesktopSwitching_Loop", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Smooth switch between virtual desktops.
-        /// </summary>
-        public static string Settings_DesktopSwitching_Smooth
-        {
-            get
-            {
-                return ResourceManager.GetString("Settings_DesktopSwitching_Smooth", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Override OS default key combination (Ctrl+Win+Left and Right).
         /// </summary>
         public static string Settings_DesktopSwitching_OverrideOS {
             get {
                 return ResourceManager.GetString("Settings_DesktopSwitching_OverrideOS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Smooth switching between virtual desktops.
+        /// </summary>
+        public static string Settings_DesktopSwitching_Smooth {
+            get {
+                return ResourceManager.GetString("Settings_DesktopSwitching_Smooth", resourceCulture);
             }
         }
         

--- a/source/SylphyHorn/Properties/Resources.Designer.cs
+++ b/source/SylphyHorn/Properties/Resources.Designer.cs
@@ -169,6 +169,33 @@ namespace SylphyHorn.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Colors.
+        /// </summary>
+        public static string Settings_Colors {
+            get {
+                return ResourceManager.GetString("Settings_Colors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Accent.
+        /// </summary>
+        public static string Settings_Colors_Accent {
+            get {
+                return ResourceManager.GetString("Settings_Colors_Accent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Theme.
+        /// </summary>
+        public static string Settings_Colors_Theme {
+            get {
+                return ResourceManager.GetString("Settings_Colors_Theme", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Desktop switching.
         /// </summary>
         public static string Settings_DesktopSwitching {

--- a/source/SylphyHorn/Properties/Resources.Designer.cs
+++ b/source/SylphyHorn/Properties/Resources.Designer.cs
@@ -185,7 +185,18 @@ namespace SylphyHorn.Properties {
                 return ResourceManager.GetString("Settings_DesktopSwitching_Loop", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Smooth switch between virtual desktops.
+        /// </summary>
+        public static string Settings_DesktopSwitching_Smooth
+        {
+            get
+            {
+                return ResourceManager.GetString("Settings_DesktopSwitching_Smooth", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Override OS default key combination (Ctrl+Win+Left and Right).
         /// </summary>

--- a/source/SylphyHorn/Properties/Resources.ja.resx
+++ b/source/SylphyHorn/Properties/Resources.ja.resx
@@ -225,6 +225,15 @@
   <data name="Settings_PinWindowFromApp" xml:space="preserve">
     <value>アプリのウィンドウをすべてのデスクトップに表示 (ピン留め)</value>
   </data>
+  <data name="Settings_Colors" xml:space="preserve">
+    <value>色</value>
+  </data>
+  <data name="Settings_Colors_Theme" xml:space="preserve">
+    <value>テーマ</value>
+  </data>
+  <data name="Settings_Colors_Accent" xml:space="preserve">
+    <value>アクセント</value>
+  </data>
   <data name="Settings_ShortcutKey" xml:space="preserve">
     <value>キー設定</value>
   </data>

--- a/source/SylphyHorn/Properties/Resources.ja.resx
+++ b/source/SylphyHorn/Properties/Resources.ja.resx
@@ -159,6 +159,9 @@
   <data name="Settings_DesktopSwitching_Loop" xml:space="preserve">
     <value>仮想デスクトップをループさせる</value>
   </data>
+  <data name="Settings_DesktopSwitching_Smooth" xml:space="preserve">
+    <value>仮想デスクトップ間のスムーズな切り替え</value>
+  </data>
   <data name="Settings_DesktopSwitching_OverrideOS" xml:space="preserve">
     <value>OS 既定のキー コンビネーションを上書きする (Ctrl+Win+Left および Right)</value>
   </data>

--- a/source/SylphyHorn/Properties/Resources.resx
+++ b/source/SylphyHorn/Properties/Resources.resx
@@ -159,6 +159,9 @@
   <data name="Settings_DesktopSwitching_Loop" xml:space="preserve">
     <value>Loop virtual desktops</value>
   </data>
+  <data name="Settings_DesktopSwitching_Smooth" xml:space="preserve">
+    <value>Smooth switch between virtual desktops</value>
+  </data>
   <data name="Settings_DesktopSwitching_OverrideOS" xml:space="preserve">
     <value>Override OS default key combination (Ctrl+Win+Left and Right)</value>
   </data>

--- a/source/SylphyHorn/Properties/Resources.resx
+++ b/source/SylphyHorn/Properties/Resources.resx
@@ -160,7 +160,7 @@
     <value>Loop virtual desktops</value>
   </data>
   <data name="Settings_DesktopSwitching_Smooth" xml:space="preserve">
-    <value>Smooth switch between virtual desktops</value>
+    <value>Smooth switching between virtual desktops</value>
   </data>
   <data name="Settings_DesktopSwitching_OverrideOS" xml:space="preserve">
     <value>Override OS default key combination (Ctrl+Win+Left and Right)</value>

--- a/source/SylphyHorn/Properties/Resources.resx
+++ b/source/SylphyHorn/Properties/Resources.resx
@@ -225,6 +225,15 @@
   <data name="Settings_PinWindowFromApp" xml:space="preserve">
     <value>Pin window from app to all desktops</value>
   </data>
+  <data name="Settings_Colors" xml:space="preserve">
+    <value>Colors</value>
+  </data>
+  <data name="Settings_Colors_Theme" xml:space="preserve">
+    <value>Theme</value>
+  </data>
+  <data name="Settings_Colors_Accent" xml:space="preserve">
+    <value>Accent</value>
+  </data>
   <data name="Settings_ShortcutKey" xml:space="preserve">
     <value>Shortcut key</value>
   </data>

--- a/source/SylphyHorn/Services/Helpers.cs
+++ b/source/SylphyHorn/Services/Helpers.cs
@@ -42,9 +42,9 @@ namespace SylphyHorn.Services
 
 	internal static class VisualHelper
 	{
-		public static void InvokeOnUIDispatcher(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
+		public static DispatcherOperation InvokeOnUIDispatcher(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
 		{
-			DispatcherHelper.UIDispatcher.BeginInvoke(action, priority);
+			return DispatcherHelper.UIDispatcher.BeginInvoke(action, priority);
 		}
 	}
 }

--- a/source/SylphyHorn/Services/HookService.cs
+++ b/source/SylphyHorn/Services/HookService.cs
@@ -33,12 +33,12 @@ namespace SylphyHorn.Services
 			});
 		}
 
-		public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr> action)
+		public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKeyDetector> action)
 		{
 			return this.Register(getShortcutKey, action, () => true);
 		}
 
-		public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr> action, Func<bool> canExecute)
+		public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKeyDetector> action, Func<bool> canExecute)
 		{
 			var hook = new HookAction(getShortcutKey, action, canExecute);
 			this._hookActions.Add(hook);
@@ -53,7 +53,7 @@ namespace SylphyHorn.Services
 			var target = this._hookActions.FirstOrDefault(x => x.GetShortcutKey() == args.ShortcutKey);
 			if (target != null && target.CanExecute())
 			{
-				VisualHelper.InvokeOnUIDispatcher(() => target.Action(InteropHelper.GetForegroundWindowEx()));
+				VisualHelper.InvokeOnUIDispatcher(() => target.Action(InteropHelper.GetForegroundWindowEx(), this._detector));
 				args.Handled = true;
 			}
 		}
@@ -67,11 +67,11 @@ namespace SylphyHorn.Services
 		{
 			public Func<ShortcutKey> GetShortcutKey { get; }
 
-			public Action<IntPtr> Action { get; }
+			public Action<IntPtr, ShortcutKeyDetector> Action { get; }
 
 			public Func<bool> CanExecute { get; }
 
-			public HookAction(Func<ShortcutKey> getShortcutKey, Action<IntPtr> action, Func<bool> canExecute)
+			public HookAction(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKeyDetector> action, Func<bool> canExecute)
 			{
 				this.GetShortcutKey = getShortcutKey;
 				this.Action = action;

--- a/source/SylphyHorn/Services/HookService.cs
+++ b/source/SylphyHorn/Services/HookService.cs
@@ -2,54 +2,58 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows.Threading;
 using MetroTrilithon.Lifetime;
 
 namespace SylphyHorn.Services
 {
 	public class HookService : IDisposable
 	{
-		private readonly ShortcutKeyDetector _detector = new ShortcutKeyDetector();
+		public readonly ShortcutKeyDetector KeyDetector = new ShortcutKeyDetector();
+
 		private readonly List<HookAction> _hookActions = new List<HookAction>();
 		private int _suspendRequestCount;
 
 		public HookService()
 		{
-			this._detector.Pressed += this.KeyHookOnPressed;
-			this._detector.Start();
+			this.KeyDetector.Pressed += this.KeyHookOnPressed;
+			this.KeyDetector.Start();
 		}
 
 		public IDisposable Suspend()
 		{
 			this._suspendRequestCount++;
-			this._detector.Stop();
+			this.KeyDetector.Stop();
 
 			return Disposable.Create(() =>
 			{
 				this._suspendRequestCount--;
 				if (this._suspendRequestCount == 0)
 				{
-					this._detector.Start();
+					this.KeyDetector.Start();
 				}
 			});
 		}
 
-		public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKeyDetector, ShortcutKey> action)
+		public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKey> action)
 		{
 			return this.Register(getShortcutKey, action, () => true);
 		}
 
-	    public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKeyDetector, ShortcutKey> action, Func<bool> canExecute)
+	    public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKey> action, Func<bool> canExecute)
 	    {
 	        return this.Register(getShortcutKey, action, canExecute, () => true);
 	    }
 
-        public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKeyDetector, ShortcutKey> action, Func<bool> canExecute, Func<bool> isHandled)
+        public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKey> action, Func<bool> canExecute, Func<bool> isHandled)
 		{
 			var hook = new HookAction(getShortcutKey, action, canExecute, isHandled);
 			this._hookActions.Add(hook);
 
 			return Disposable.Create(() => this._hookActions.Remove(hook));
 		}
+
+	    private DispatcherOperation _activeDispatcherOperation;
 
 		private void KeyHookOnPressed(object sender, ShortcutKeyPressedEventArgs args)
 		{
@@ -58,27 +62,32 @@ namespace SylphyHorn.Services
 			var target = this._hookActions.FirstOrDefault(x => x.GetShortcutKey() == args.ShortcutKey);
 			if (target != null && target.CanExecute())
 			{
-				VisualHelper.InvokeOnUIDispatcher(() => target.Action(InteropHelper.GetForegroundWindowEx(), this._detector, target.GetShortcutKey()));
-				args.Handled = target.IsHandled();
+			    if (this._activeDispatcherOperation == null || this._activeDispatcherOperation.Task.IsCompleted)
+			    {
+			        Console.WriteLine();
+                    Console.WriteLine($"Received shortcut key: {target.GetShortcutKey()}");
+			        this._activeDispatcherOperation = VisualHelper.InvokeOnUIDispatcher(() => target.Action(InteropHelper.GetForegroundWindowEx(), target.GetShortcutKey()));
+			    }
+			    args.Handled = target.IsHandled();
 			}
 		}
 
 		public void Dispose()
 		{
-			this._detector.Stop();
+			this.KeyDetector.Stop();
 		}
 
 		private class HookAction
 		{
 			public Func<ShortcutKey> GetShortcutKey { get; }
 
-			public Action<IntPtr, ShortcutKeyDetector, ShortcutKey> Action { get; }
+			public Action<IntPtr, ShortcutKey> Action { get; }
 
 			public Func<bool> CanExecute { get; }
 
             public Func<bool> IsHandled { get; }
 
-			public HookAction(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKeyDetector, ShortcutKey> action, Func<bool> canExecute, Func<bool> isHandled)
+			public HookAction(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKey> action, Func<bool> canExecute, Func<bool> isHandled)
 			{
 				this.GetShortcutKey = getShortcutKey;
 				this.Action = action;

--- a/source/SylphyHorn/Services/HookService.cs
+++ b/source/SylphyHorn/Services/HookService.cs
@@ -33,14 +33,19 @@ namespace SylphyHorn.Services
 			});
 		}
 
-		public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKeyDetector> action)
+		public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKeyDetector, ShortcutKey> action)
 		{
 			return this.Register(getShortcutKey, action, () => true);
 		}
 
-		public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKeyDetector> action, Func<bool> canExecute)
+	    public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKeyDetector, ShortcutKey> action, Func<bool> canExecute)
+	    {
+	        return this.Register(getShortcutKey, action, canExecute, () => true);
+	    }
+
+        public IDisposable Register(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKeyDetector, ShortcutKey> action, Func<bool> canExecute, Func<bool> isHandled)
 		{
-			var hook = new HookAction(getShortcutKey, action, canExecute);
+			var hook = new HookAction(getShortcutKey, action, canExecute, isHandled);
 			this._hookActions.Add(hook);
 
 			return Disposable.Create(() => this._hookActions.Remove(hook));
@@ -53,8 +58,8 @@ namespace SylphyHorn.Services
 			var target = this._hookActions.FirstOrDefault(x => x.GetShortcutKey() == args.ShortcutKey);
 			if (target != null && target.CanExecute())
 			{
-				VisualHelper.InvokeOnUIDispatcher(() => target.Action(InteropHelper.GetForegroundWindowEx(), this._detector));
-				args.Handled = true;
+				VisualHelper.InvokeOnUIDispatcher(() => target.Action(InteropHelper.GetForegroundWindowEx(), this._detector, target.GetShortcutKey()));
+				args.Handled = target.IsHandled();
 			}
 		}
 
@@ -67,15 +72,18 @@ namespace SylphyHorn.Services
 		{
 			public Func<ShortcutKey> GetShortcutKey { get; }
 
-			public Action<IntPtr, ShortcutKeyDetector> Action { get; }
+			public Action<IntPtr, ShortcutKeyDetector, ShortcutKey> Action { get; }
 
 			public Func<bool> CanExecute { get; }
 
-			public HookAction(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKeyDetector> action, Func<bool> canExecute)
+            public Func<bool> IsHandled { get; }
+
+			public HookAction(Func<ShortcutKey> getShortcutKey, Action<IntPtr, ShortcutKeyDetector, ShortcutKey> action, Func<bool> canExecute, Func<bool> isHandled)
 			{
 				this.GetShortcutKey = getShortcutKey;
 				this.Action = action;
 				this.CanExecute = canExecute;
+			    this.IsHandled = isHandled;
 			}
 		}
 	}

--- a/source/SylphyHorn/Services/ResourceService.cs
+++ b/source/SylphyHorn/Services/ResourceService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Livet;
+using MetroRadiance.UI;
 using SylphyHorn.Properties;
 using SylphyHorn.Serialization;
 
@@ -35,7 +36,12 @@ namespace SylphyHorn.Services
 		/// </summary>
 		public IReadOnlyCollection<CultureInfo> SupportedCultures { get; }
 
-		private ResourceService()
+        public IReadOnlyCollection<Theme> SupportedThemes { get; }
+
+        public IReadOnlyCollection<Accent> SupportedAccents { get; }
+
+
+        private ResourceService()
 		{
 			this.Resources = new Resources();
 			this.SupportedCultures = this._supportedCultureNames
@@ -52,6 +58,21 @@ namespace SylphyHorn.Services
 				})
 				.Where(x => x != null)
 				.ToList();
+
+		    this.SupportedThemes = new[]
+		    {
+		        Theme.Dark,
+		        Theme.Light,
+		        Theme.Windows
+		    };
+
+		    this.SupportedAccents = new[]
+		    {
+		        Accent.Blue,
+		        Accent.Orange,
+		        Accent.Purple,
+		        Accent.Windows
+		    };
 		}
 
 		/// <summary>

--- a/source/SylphyHorn/Services/ShortcutKey.cs
+++ b/source/SylphyHorn/Services/ShortcutKey.cs
@@ -40,7 +40,13 @@ namespace SylphyHorn.Services
 			return this == other;
 		}
 
-		public override bool Equals(object obj)
+	    public bool Equals(IShortcutKey other)
+	    {
+            if (ReferenceEquals(null, other)) return false;
+            return other is ShortcutKey && this.Equals((ShortcutKey)other);
+        }
+
+        public override bool Equals(object obj)
 		{
 			if (ReferenceEquals(null, obj)) return false;
 			return obj is ShortcutKey && this.Equals((ShortcutKey)obj);

--- a/source/SylphyHorn/Services/ShortcutKey.cs
+++ b/source/SylphyHorn/Services/ShortcutKey.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using WindowsDesktop;
 using MetroTrilithon.Linq;
 
 #if WINDOWS_UWP
@@ -14,7 +15,7 @@ namespace SylphyHorn.Services
 	/// <summary>
 	/// Represents a shortcut key ([modifer key(s)] + [key] style).
 	/// </summary>
-	public struct ShortcutKey
+	public struct ShortcutKey : IShortcutKey
 	{
 		public VirtualKey Key { get; }
 		public VirtualKey[] Modifiers { get; }

--- a/source/SylphyHorn/Services/ShortcutKey.cs
+++ b/source/SylphyHorn/Services/ShortcutKey.cs
@@ -29,10 +29,10 @@ namespace SylphyHorn.Services
 			this.ModifiersInternal = modifiers;
 		}
 
-		internal ShortcutKey(VirtualKey key, ICollection<VirtualKey> modifiers) : this()
+		internal ShortcutKey(VirtualKey key, IReadOnlyCollection<VirtualKey> modifiers) : this()
 		{
 			this.Key = key;
-			this.ModifiersInternal = modifiers;
+			this.ModifiersInternal = new List<VirtualKey>(modifiers);
 		}
 
 		public bool Equals(ShortcutKey other)
@@ -54,12 +54,13 @@ namespace SylphyHorn.Services
 
 		public override int GetHashCode()
 		{
-			unchecked
-			{
-				var hashCode = (this.ModifiersInternal ?? this.Modifiers)?.GetHashCode() ?? 0;
-				hashCode = (hashCode * 397) ^ (int)this.Key;
-				return hashCode;
-			}
+			//unchecked
+			//{
+			//	var hashCode = (this.ModifiersInternal ?? this.Modifiers)?.GetHashCode() ?? 0;
+			//	hashCode = (hashCode * 397) ^ (int)this.Key;
+			//	return hashCode;
+			//}
+		    return this.ToString().GetHashCode();
 		}
 
 		public override string ToString()

--- a/source/SylphyHorn/Services/ShortcutKeyAccumulator.cs
+++ b/source/SylphyHorn/Services/ShortcutKeyAccumulator.cs
@@ -52,7 +52,7 @@ namespace SylphyHorn.Services
 
         public void Clear()
         {
-            this._pressedModifiers.Clear();
+            this._pressedKeys.Clear();
             this._pressedModifiers.Clear();
         }
     }

--- a/source/SylphyHorn/Services/ShortcutKeyAccumulator.cs
+++ b/source/SylphyHorn/Services/ShortcutKeyAccumulator.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace SylphyHorn.Services
+{
+    public class ShortcutKeyAccumulator
+    {
+        private readonly HashSet<Keys> _pressedModifiers = new HashSet<Keys>();
+        private readonly HashSet<Keys> _pressedKeys = new HashSet<Keys>();
+
+        public IReadOnlyCollection<Keys> Modifiers => this._pressedModifiers;
+
+        public IReadOnlyCollection<Keys> Keys => this._pressedKeys;
+
+
+        public void Add(Keys keyCode)
+        {
+            if (keyCode.IsModifyKey())
+            {
+                this._pressedModifiers.Add(keyCode);
+            }
+            else
+            {
+                this._pressedKeys.Add(keyCode);
+            }
+        }
+
+        public void Remove(Keys keyCode)
+        {
+            if (this._pressedModifiers.Contains(keyCode) && keyCode.IsModifyKey())
+            {
+                this._pressedModifiers.Remove(keyCode);
+            }
+
+            if (this._pressedKeys.Contains(keyCode) && !keyCode.IsModifyKey())
+            {
+                this._pressedKeys.Remove(keyCode);
+            }
+        }
+
+        public IEnumerable<ShortcutKey> GetShortcutKeys()
+        {
+            foreach (var key in this._pressedKeys)
+            {
+                yield return new ShortcutKey(key, this._pressedModifiers);
+            }
+        }
+
+        public void Clear()
+        {
+            this._pressedModifiers.Clear();
+            this._pressedModifiers.Clear();
+        }
+    }
+}

--- a/source/SylphyHorn/Services/ShortcutKeyDetector.cs
+++ b/source/SylphyHorn/Services/ShortcutKeyDetector.cs
@@ -1,76 +1,100 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Windows.Forms;
+using WindowsDesktop;
 using Open.WinKeyboardHook;
 
 namespace SylphyHorn.Services
 {
-	/// <summary>
-	/// Provides the function to detect a shortcut key ([modifier key(s)] + [key] style) by use of global key hook.
-	/// </summary>
-	public class ShortcutKeyDetector
-	{
-		private readonly HashSet<Keys> _pressedModifiers = new HashSet<Keys>();
-		private readonly IKeyboardInterceptor _interceptor = new KeyboardInterceptor();
+    /// <summary>
+    /// Provides the function to detect a shortcut key ([modifier key(s)] + [key] style) by use of global key hook.
+    /// </summary>
+    public class ShortcutKeyDetector : IShortcutKeyDetector
+    {
+        private readonly HashSet<Keys> _pressedModifiers = new HashSet<Keys>();
+        private readonly HashSet<Keys> _regularKeys = new HashSet<Keys>();
+        private readonly IKeyboardInterceptor _interceptor = new KeyboardInterceptor();
 
-		private bool _started;
-		private bool _suspended;
+        private bool _started;
+        private bool _suspended;
 
-		/// <summary>
-		/// Occurs when detects a shortcut key.
-		/// </summary>
-		public event EventHandler<ShortcutKeyPressedEventArgs> Pressed;
+        private readonly ManualResetEvent _noKeysPressedEvent = new ManualResetEvent(true);
 
-		public ShortcutKeyDetector()
-		{
-			this._interceptor.KeyDown += this.InterceptorOnKeyDown;
-			this._interceptor.KeyUp += this.InterceptorOnKeyUp;
-		}
+        /// <summary>
+        /// Occurs when detects a shortcut key.
+        /// </summary>
+        public event EventHandler<ShortcutKeyPressedEventArgs> Pressed;
 
-		public void Start()
-		{
-			if (!this._started)
-			{
-				this._interceptor.StartCapturing();
-				this._started = true;
-			}
+        public ShortcutKeyDetector()
+        {
+            this._interceptor.KeyDown += this.InterceptorOnKeyDown;
+            this._interceptor.KeyUp += this.InterceptorOnKeyUp;
+        }
 
-			this._suspended = false;
-		}
+        public void Start()
+        {
+            if (!this._started)
+            {
+                this._interceptor.StartCapturing();
+                this._started = true;
+            }
 
-		public void Stop()
-		{
-			this._suspended = true;
-			this._pressedModifiers.Clear();
-		}
+            this._suspended = false;
+        }
 
-		private void InterceptorOnKeyDown(object sender, KeyEventArgs args)
-		{
-			if (this._suspended) return;
+        public void Stop()
+        {
+            this._suspended = true;
+            this._pressedModifiers.Clear();
+        }
 
-			if (args.KeyCode.IsModifyKey())
-			{
-				this._pressedModifiers.Add(args.KeyCode);
-			}
-			else
-			{
-				var pressedEventArgs = new ShortcutKeyPressedEventArgs(args.KeyCode, this._pressedModifiers);
-				this.Pressed?.Invoke(this, pressedEventArgs);
-				if (pressedEventArgs.Handled) args.SuppressKeyPress = true;
-			}
-		}
+        public bool WaitForNoKeysPressed()
+        {
+            if (this._suspended) return false;
 
-		private void InterceptorOnKeyUp(object sender, KeyEventArgs args)
-		{
-			if (this._suspended) return;
+            return this._noKeysPressedEvent.WaitOne();
+        }
 
-			if (this._pressedModifiers.Count == 0) return;
+        private void InterceptorOnKeyDown(object sender, KeyEventArgs args)
+        {
+            if (this._suspended) return;
 
-			if (args.KeyCode.IsModifyKey())
-			{
-				this._pressedModifiers.Remove(args.KeyCode);
-			}
-		}
-	}
+            this._noKeysPressedEvent.Reset();
+
+            if (args.KeyCode.IsModifyKey())
+            {
+                this._pressedModifiers.Add(args.KeyCode);
+            }
+            else
+            {
+                this._regularKeys.Add(args.KeyCode);
+
+                var pressedEventArgs = new ShortcutKeyPressedEventArgs(args.KeyCode, this._pressedModifiers);
+                this.Pressed?.Invoke(this, pressedEventArgs);
+                if (pressedEventArgs.Handled) args.SuppressKeyPress = true;
+            }
+        }
+
+        private void InterceptorOnKeyUp(object sender, KeyEventArgs args)
+        {
+            if (this._suspended) return;
+
+            if (this._pressedModifiers.Count != 0 && args.KeyCode.IsModifyKey())
+            {
+                this._pressedModifiers.Remove(args.KeyCode);
+            }
+
+            if (this._regularKeys.Count != 0 && !args.KeyCode.IsModifyKey())
+            {
+                this._regularKeys.Remove(args.KeyCode);
+            }
+
+            if (!this._pressedModifiers.Any() && !this._regularKeys.Any())
+            {
+                this._noKeysPressedEvent.Set();
+            }
+        }
+    }
 }

--- a/source/SylphyHorn/Services/ShortcutKeyPressedEventArgs.cs
+++ b/source/SylphyHorn/Services/ShortcutKeyPressedEventArgs.cs
@@ -15,7 +15,7 @@ namespace SylphyHorn.Services
 			this.ShortcutKey = shortcutKey;
 		}
 
-		internal ShortcutKeyPressedEventArgs(Keys key, ICollection<Keys> modifiers)
+		internal ShortcutKeyPressedEventArgs(Keys key, IReadOnlyCollection<Keys> modifiers)
 		{
 			this.ShortcutKey = new ShortcutKey(key, modifiers);
 		}

--- a/source/SylphyHorn/Services/VirtualDesktopService.cs
+++ b/source/SylphyHorn/Services/VirtualDesktopService.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Media;
 using SylphyHorn.Serialization;
 using WindowsDesktop;
+using WindowsDesktop.Interop;
 
 namespace SylphyHorn.Services
 {
@@ -12,34 +13,36 @@ namespace SylphyHorn.Services
 
 		public static VirtualDesktop GetLeft()
 		{
-			var current = VirtualDesktop.Current;
-			var desktops = VirtualDesktop.GetDesktops();
-
-			return desktops.Length >= 2 && current.Id == desktops.First().Id
-				? Settings.General.LoopDesktop ? desktops.Last() : null
-				: current.GetLeft();
+			var current = VirtualDesktop.CurrentOrDesktopToSwitchTo;
+		    return GetLeftOf(current);
 		}
 
-		public static VirtualDesktop GetRight()
+        public static VirtualDesktop GetLeftOf(VirtualDesktop current)
+        {
+            return current.GetLeft(Settings.General.LoopDesktop);
+        }
+
+        public static VirtualDesktop GetRight()
 		{
-			var current = VirtualDesktop.Current;
-			var desktops = VirtualDesktop.GetDesktops();
-
-			return desktops.Length >= 2 && current.Id == desktops.Last().Id
-				? Settings.General.LoopDesktop ? desktops.First() : null
-				: current.GetRight();
+			var current = VirtualDesktop.CurrentOrDesktopToSwitchTo;
+		    return GetRightOf(current);
 		}
 
-		#endregion
+        public static VirtualDesktop GetRightOf(VirtualDesktop current)
+        {
+            return current.GetRight(Settings.General.LoopDesktop);
+        }
 
-		#region Move
+        #endregion
 
-		public static VirtualDesktop MoveToLeft(this IntPtr hWnd)
+        #region Move
+
+        public static VirtualDesktop MoveToLeft(this IntPtr hWnd)
 		{
 			var current = VirtualDesktop.FromHwnd(hWnd);
 			if (current != null)
 			{
-				var left = current.GetLeft();
+				var left = current.GetLeft(Settings.General.LoopDesktop);
 				if (left == null)
 				{
 					if (Settings.General.LoopDesktop)
@@ -50,8 +53,8 @@ namespace SylphyHorn.Services
 				}
 				if (left != null)
 				{
-					VirtualDesktopHelper.MoveToDesktop(hWnd, left);
-					return left;
+					VirtualDesktopHelper.MoveToDesktop(hWnd, left, AdjacentDesktop.LeftDirection, Settings.General.LoopDesktop);
+				    return left;
 				}
 			}
 
@@ -64,7 +67,7 @@ namespace SylphyHorn.Services
 			var current = VirtualDesktop.FromHwnd(hWnd);
 			if (current != null)
 			{
-				var right = current.GetRight();
+				var right = current.GetRight(Settings.General.LoopDesktop);
 				if (right == null)
 				{
 					if (Settings.General.LoopDesktop)
@@ -75,8 +78,8 @@ namespace SylphyHorn.Services
 				}
 				if (right != null)
 				{
-					VirtualDesktopHelper.MoveToDesktop(hWnd, right);
-					return right;
+					VirtualDesktopHelper.MoveToDesktop(hWnd, right, AdjacentDesktop.RightDirection, Settings.General.LoopDesktop);
+				    return right;
 				}
 			}
 
@@ -89,8 +92,8 @@ namespace SylphyHorn.Services
 			var newone = VirtualDesktop.Create();
 			if (newone != null)
 			{
-				VirtualDesktopHelper.MoveToDesktop(hWnd, newone);
-				return newone;
+				VirtualDesktopHelper.MoveToDesktop(hWnd, newone, AdjacentDesktop.Jump, false);
+			    return newone;
 			}
 
 			SystemSounds.Asterisk.Play();
@@ -101,26 +104,26 @@ namespace SylphyHorn.Services
 
 		#region Close
 
-		public static void CloseAndSwitchLeft(IShortcutKeyDetector keyDetector, bool smoothSwitch, IShortcutKey switchLeftShortcutKey, IShortcutKey switchRightShortcutKey)
+		public static void CloseAndSwitchLeft(SmoothSwitchData switchData)
 		{
 			var current = VirtualDesktop.Current;
 			var desktops = VirtualDesktop.GetDesktops();
 			
 			if (desktops.Length > 1)
 			{
-				GetLeft()?.Switch(keyDetector, smoothSwitch, switchLeftShortcutKey, switchRightShortcutKey);
+				GetLeft()?.Switch(switchData, AdjacentDesktop.LeftDirection, Settings.General.LoopDesktop).Execute(null);
 				current.Remove();
 			}
 		}
 
-		public static void CloseAndSwitchRight(IShortcutKeyDetector keyDetector, bool smoothSwitch, IShortcutKey switchLeftShortcutKey, IShortcutKey switchRightShortcutKey)
+		public static void CloseAndSwitchRight(SmoothSwitchData switchData)
 		{
 			var current = VirtualDesktop.Current;
 			var desktops = VirtualDesktop.GetDesktops();
 
 			if (desktops.Length > 1)
 			{
-				GetRight()?.Switch(keyDetector, smoothSwitch, switchLeftShortcutKey, switchRightShortcutKey);
+				GetRight()?.Switch(switchData, AdjacentDesktop.RightDirection, Settings.General.LoopDesktop).Execute(null);
 				current.Remove();
 			}
 		}

--- a/source/SylphyHorn/Services/VirtualDesktopService.cs
+++ b/source/SylphyHorn/Services/VirtualDesktopService.cs
@@ -101,26 +101,26 @@ namespace SylphyHorn.Services
 
 		#region Close
 
-		public static void CloseAndSwitchLeft(IntPtr hWnd, IShortcutKeyDetector keyDetector, bool smoothSwitch, IShortcutKey switchLeftShortcutKey, IShortcutKey switchRightShortcutKey)
+		public static void CloseAndSwitchLeft(IShortcutKeyDetector keyDetector, bool smoothSwitch, IShortcutKey switchLeftShortcutKey, IShortcutKey switchRightShortcutKey)
 		{
 			var current = VirtualDesktop.Current;
 			var desktops = VirtualDesktop.GetDesktops();
 			
 			if (desktops.Length > 1)
 			{
-				GetLeft()?.Switch(hWnd, keyDetector, smoothSwitch, switchLeftShortcutKey, switchRightShortcutKey);
+				GetLeft()?.Switch(keyDetector, smoothSwitch, switchLeftShortcutKey, switchRightShortcutKey);
 				current.Remove();
 			}
 		}
 
-		public static void CloseAndSwitchRight(IntPtr hWnd, IShortcutKeyDetector keyDetector, bool smoothSwitch, IShortcutKey switchLeftShortcutKey, IShortcutKey switchRightShortcutKey)
+		public static void CloseAndSwitchRight(IShortcutKeyDetector keyDetector, bool smoothSwitch, IShortcutKey switchLeftShortcutKey, IShortcutKey switchRightShortcutKey)
 		{
 			var current = VirtualDesktop.Current;
 			var desktops = VirtualDesktop.GetDesktops();
 
 			if (desktops.Length > 1)
 			{
-				GetRight()?.Switch(hWnd, keyDetector, smoothSwitch, switchLeftShortcutKey, switchRightShortcutKey);
+				GetRight()?.Switch(keyDetector, smoothSwitch, switchLeftShortcutKey, switchRightShortcutKey);
 				current.Remove();
 			}
 		}

--- a/source/SylphyHorn/Services/VirtualDesktopService.cs
+++ b/source/SylphyHorn/Services/VirtualDesktopService.cs
@@ -101,26 +101,26 @@ namespace SylphyHorn.Services
 
 		#region Close
 
-		public static void CloseAndSwitchLeft()
+		public static void CloseAndSwitchLeft(IntPtr hWnd, IShortcutKeyDetector keyDetector, bool smoothSwitch, IShortcutKey switchLeftShortcutKey, IShortcutKey switchRightShortcutKey)
 		{
 			var current = VirtualDesktop.Current;
 			var desktops = VirtualDesktop.GetDesktops();
 			
 			if (desktops.Length > 1)
 			{
-				GetLeft()?.Switch();
+				GetLeft()?.Switch(hWnd, keyDetector, smoothSwitch, switchLeftShortcutKey, switchRightShortcutKey);
 				current.Remove();
 			}
 		}
 
-		public static void CloseAndSwitchRight()
+		public static void CloseAndSwitchRight(IntPtr hWnd, IShortcutKeyDetector keyDetector, bool smoothSwitch, IShortcutKey switchLeftShortcutKey, IShortcutKey switchRightShortcutKey)
 		{
 			var current = VirtualDesktop.Current;
 			var desktops = VirtualDesktop.GetDesktops();
 
 			if (desktops.Length > 1)
 			{
-				GetRight()?.Switch();
+				GetRight()?.Switch(hWnd, keyDetector, smoothSwitch, switchLeftShortcutKey, switchRightShortcutKey);
 				current.Remove();
 			}
 		}

--- a/source/SylphyHorn/SylphyHorn.csproj
+++ b/source/SylphyHorn/SylphyHorn.csproj
@@ -209,6 +209,7 @@
     </Compile>
     <Compile Include="Services\LoggingService.cs" />
     <Compile Include="Services\ResourceService.cs" />
+    <Compile Include="Services\ShortcutKeyAccumulator.cs" />
     <Compile Include="Startup.cs" />
     <Compile Include="UI\Controls\BlurWindow.cs" />
     <Compile Include="UI\Controls\Keytop.cs" />

--- a/source/SylphyHorn/SylphyHorn.csproj
+++ b/source/SylphyHorn/SylphyHorn.csproj
@@ -108,6 +108,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>SylphyHorn.Application</StartupObject>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="JetBrains.Annotations, Version=10.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
       <HintPath>..\packages\JetBrains.Annotations.10.2.1\lib\net\JetBrains.Annotations.dll</HintPath>

--- a/source/SylphyHorn/UI/Bindings/SettingsWindowViewModel.cs
+++ b/source/SylphyHorn/UI/Bindings/SettingsWindowViewModel.cs
@@ -22,6 +22,10 @@ namespace SylphyHorn.UI.Bindings
 
 		public IReadOnlyCollection<DisplayViewModel<string>> Cultures { get; }
 
+        public IReadOnlyCollection<DisplayViewModel<string>> Themes { get; }
+
+        public IReadOnlyCollection<DisplayViewModel<string>> Accents { get; }
+
 		public IReadOnlyCollection<BindableTextViewModel> Libraries { get; }
 
 		public bool RestartRequired => _restartRequired;
@@ -72,11 +76,47 @@ namespace SylphyHorn.UI.Bindings
 			}
 		}
 
-		#endregion
+        #endregion
 
-		#region Backgrounds notification property
+        #region Colors notification properties
 
-		private WallpaperFile[] _Backgrounds;
+        public string Theme
+        {
+            get { return Settings.General.Theme; }
+            set
+            {
+                if (Settings.General.Theme != value)
+                {
+                    Settings.General.Theme.Value = value;
+                    //_restartRequired = value != _defaultCulture;
+
+                    this.RaisePropertyChanged();
+                    //this.RaisePropertyChanged(nameof(this.RestartRequired));
+                }
+            }
+        }
+
+        public string Accent
+        {
+            get { return Settings.General.Accent; }
+            set
+            {
+                if (Settings.General.Accent != value)
+                {
+                    Settings.General.Accent.Value = value;
+                    //_restartRequired = value != _defaultCulture;
+
+                    this.RaisePropertyChanged();
+                    //this.RaisePropertyChanged(nameof(this.RestartRequired));
+                }
+            }
+        }
+
+        #endregion
+
+        #region Backgrounds notification property
+
+        private WallpaperFile[] _Backgrounds;
 
 		public WallpaperFile[] Backgrounds
 		{
@@ -104,7 +144,19 @@ namespace SylphyHorn.UI.Bindings
 					.OrderBy(x => x.Display))
 				.ToList();
 
-			this.Libraries = ProductInfo.Libraries.Aggregate(
+		    this.Themes = new DisplayViewModel<string>[] { }
+		        .Concat(ResourceService.Current.SupportedThemes
+		            .Select(x => new DisplayViewModel<string> { Display = x.ToString(), Value = x.Specified?.ToString() })
+		            .OrderBy(x => x.Display))
+		        .ToList();
+
+            this.Accents = new DisplayViewModel<string>[] { }
+                .Concat(ResourceService.Current.SupportedAccents
+                    .Select(x => new DisplayViewModel<string> { Display = x.ToString(), Value = x.Specified?.ToString() })
+                    .OrderBy(x => x.Display))
+                .ToList();
+
+            this.Libraries = ProductInfo.Libraries.Aggregate(
 				new List<BindableTextViewModel>(),
 				(list, lib) =>
 				{

--- a/source/SylphyHorn/UI/SettingsWindow.xaml
+++ b/source/SylphyHorn/UI/SettingsWindow.xaml
@@ -130,7 +130,10 @@
 							<CheckBox IsChecked="{Binding Source={x:Static serialization:Settings.General}, Path=LoopDesktop.Value, Mode=TwoWay}">
 								<TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_DesktopSwitching_Loop}" />
 							</CheckBox>
-							<CheckBox IsChecked="{Binding Source={x:Static serialization:Settings.General}, Path=OverrideWindowsDefaultKeyCombination.Value, Mode=TwoWay}">
+                            <CheckBox IsChecked="{Binding Source={x:Static serialization:Settings.General}, Path=SmoothSwitch.Value, Mode=TwoWay}">
+                                <TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_DesktopSwitching_Smooth}" />
+                            </CheckBox>
+                            <CheckBox IsChecked="{Binding Source={x:Static serialization:Settings.General}, Path=OverrideWindowsDefaultKeyCombination.Value, Mode=TwoWay}">
 								<TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_DesktopSwitching_OverrideOS}" />
 							</CheckBox>
 						</StackPanel>

--- a/source/SylphyHorn/UI/SettingsWindow.xaml
+++ b/source/SylphyHorn/UI/SettingsWindow.xaml
@@ -162,7 +162,36 @@
 						<Border Height="8" />
 
 
-						<TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_Startup}"
+                        <TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_Colors}"
+								   Style="{DynamicResource HeaderStyleKey}" />
+                        <StackPanel Margin="8,0,0,0">
+                            <TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_Colors_Theme}" />
+                            <Border Height="2" />
+                            <metro:PromptComboBox ItemsSource="{Binding Themes}"
+												  DisplayMemberPath="Display"
+												  SelectedValuePath="Value"
+												  SelectedValue="{Binding Theme, Mode=TwoWay}"
+												  Prompt=""
+												  IsReadOnly="True"
+												  MinWidth="250"
+												  Margin="1,0,0,0"
+												  HorizontalAlignment="Left" />
+
+                            <TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_Colors_Accent}" />
+                            <Border Height="2" />
+                            <metro:PromptComboBox ItemsSource="{Binding Accents}"
+												  DisplayMemberPath="Display"
+												  SelectedValuePath="Value"
+												  SelectedValue="{Binding Accent, Mode=TwoWay}"
+												  Prompt=""
+												  IsReadOnly="True"
+												  MinWidth="250"
+												  Margin="1,0,0,0"
+												  HorizontalAlignment="Left" />
+                        </StackPanel>
+                        <Border Height="8" />
+
+                        <TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_Startup}"
 								   Style="{DynamicResource HeaderStyleKey}" />
 						<StackPanel Margin="8,0,0,0">
 							<CheckBox IsChecked="{Binding HasStartupLink, Mode=TwoWay}">


### PR DESCRIPTION
Smooth switching is animated switching, which is the Windows default switch "slide" animation. It's accomplished by queuing inputs from the user, deciding which desktop they want to switch to (including wrap support), and generating the necessary key presses to make the animations happen.

Looping support was added to the VirtualDesktop library. A summary of the commit logs is below.

Configurable Theme and Accent colors in General settings pane.

Added settings toggle for smooth switching (english provided by me,
and japanese provided by google translate)

ShortcutKey implements IShortcutKey interface

ShortcutKeyDetector implements IShortcutKeyDetector interface with
new WaitForNoKeysPressed method

All necessary parameters passed for smooth desktop switching
develop

Implementation of SuspendUntil(key count).

Only allow a single shortcutKey handler to be active at a time. Simply
ignore all input until the current handler has completed.

Added ShortcutKeyAccumulator.