### PR TITLE
Improve wallpaper support

### DIFF
--- a/source/SylphyHorn.Core/Serialization/GeneralSettings.cs
+++ b/source/SylphyHorn.Core/Serialization/GeneralSettings.cs
@@ -33,6 +33,8 @@ namespace SylphyHorn.Serialization
 
 		public SerializableProperty<string> Culture => this.Cache(key => new SerializableProperty<string>(key, this._provider));
 
+		public SerializableProperty<byte> Position => this.Cache(key => new SerializableProperty<byte>(key, this._provider, 4 /* Fill */));
+
 		public SerializableProperty<uint> Placement => this.Cache(key => new SerializableProperty<uint>(key, this._provider, 5 /* Center */));
 
 		public SerializableProperty<uint> Display => this.Cache(key => new SerializableProperty<uint>(key, this._provider, 0));

--- a/source/SylphyHorn/Application.xaml
+++ b/source/SylphyHorn/Application.xaml
@@ -2,6 +2,7 @@
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:converters="http://schemes.grabacr.net/winfx/2015/personal/converters"
+			 xmlns:converters2="clr-namespace:SylphyHorn.UI.Converters"
 			 xmlns:controls="clr-namespace:SylphyHorn.UI.Controls">
 	<Application.Resources>
 		<ResourceDictionary>
@@ -21,6 +22,7 @@
 			<converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
 			<converters:ReverseBooleanConverter x:Key="ReverseBooleanConverter" />
 			<converters:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
+			<converters2:ArrayToStringConverter x:Key="ArrayToStringConverter" />
 			<controls:UnlockImageConverter x:Key="UnlockImageConverter" />
 		</ResourceDictionary>
 	</Application.Resources>

--- a/source/SylphyHorn/Properties/Resources.Designer.cs
+++ b/source/SylphyHorn/Properties/Resources.Designer.cs
@@ -124,6 +124,69 @@ namespace SylphyHorn.Properties {
         }
         
         /// <summary>
+        ///   Choose a default position に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Settings_Background_Position {
+            get {
+                return ResourceManager.GetString("Settings_Background_Position", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Center に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Settings_Background_Position_Center {
+            get {
+                return ResourceManager.GetString("Settings_Background_Position_Center", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Fill に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Settings_Background_Position_Fill {
+            get {
+                return ResourceManager.GetString("Settings_Background_Position_Fill", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Fit に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Settings_Background_Position_Fit {
+            get {
+                return ResourceManager.GetString("Settings_Background_Position_Fit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Span に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Settings_Background_Position_Span {
+            get {
+                return ResourceManager.GetString("Settings_Background_Position_Span", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Stretch に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Settings_Background_Position_Stretch {
+            get {
+                return ResourceManager.GetString("Settings_Background_Position_Stretch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Tile に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string Settings_Background_Position_Tile {
+            get {
+                return ResourceManager.GetString("Settings_Background_Position_Tile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Select Background Images Folder に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string Settings_Background_SelectionDialog {

--- a/source/SylphyHorn/Properties/Resources.Designer.cs
+++ b/source/SylphyHorn/Properties/Resources.Designer.cs
@@ -106,7 +106,7 @@ namespace SylphyHorn.Properties {
         }
         
         /// <summary>
-        ///   Supported image formats: JPEG, PNG, BMP に類似しているローカライズされた文字列を検索します。
+        ///   Supported image formats: に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string Settings_Background_Note1 {
             get {

--- a/source/SylphyHorn/Properties/Resources.ja.resx
+++ b/source/SylphyHorn/Properties/Resources.ja.resx
@@ -133,7 +133,7 @@
     <value>デスクトップの背景</value>
   </data>
   <data name="Settings_Background_Note1" xml:space="preserve">
-    <value>サポートされている画像形式: JPG, PNG, BMP</value>
+    <value>サポートされている画像形式:</value>
   </data>
   <data name="Settings_Background_Note2" xml:space="preserve">
     <value>メモ: 仮想デスクトップ番号をファイル名とした画像ファイルを用意してください (例: "1.png", "2.png", ...)。</value>

--- a/source/SylphyHorn/Properties/Resources.ja.resx
+++ b/source/SylphyHorn/Properties/Resources.ja.resx
@@ -138,6 +138,27 @@
   <data name="Settings_Background_Note2" xml:space="preserve">
     <value>メモ: 仮想デスクトップ番号をファイル名とした画像ファイルを用意してください (例: "1.png", "2.png", ...)。</value>
   </data>
+  <data name="Settings_Background_Position" xml:space="preserve">
+    <value>既定の配置方法を選ぶ</value>
+  </data>
+  <data name="Settings_Background_Position_Center" xml:space="preserve">
+    <value>中央に表示</value>
+  </data>
+  <data name="Settings_Background_Position_Fill" xml:space="preserve">
+    <value>画面のサイズに合わせる</value>
+  </data>
+  <data name="Settings_Background_Position_Fit" xml:space="preserve">
+    <value>ページ幅に合わせる</value>
+  </data>
+  <data name="Settings_Background_Position_Span" xml:space="preserve">
+    <value>スパン</value>
+  </data>
+  <data name="Settings_Background_Position_Stretch" xml:space="preserve">
+    <value>拡大して表示</value>
+  </data>
+  <data name="Settings_Background_Position_Tile" xml:space="preserve">
+    <value>並べて表示</value>
+  </data>
   <data name="Settings_Background_SelectionDialog" xml:space="preserve">
     <value>背景画像フォルダーを選択</value>
   </data>

--- a/source/SylphyHorn/Properties/Resources.resx
+++ b/source/SylphyHorn/Properties/Resources.resx
@@ -133,7 +133,7 @@
     <value>Desktop background</value>
   </data>
   <data name="Settings_Background_Note1" xml:space="preserve">
-    <value>Supported image formats: JPEG, PNG, BMP</value>
+    <value>Supported image formats:</value>
   </data>
   <data name="Settings_Background_Note2" xml:space="preserve">
     <value>Note: Please prepare image files with the virtual desktop number as filename (e.g. "1.png", "2.png", ...).</value>

--- a/source/SylphyHorn/Properties/Resources.resx
+++ b/source/SylphyHorn/Properties/Resources.resx
@@ -138,6 +138,27 @@
   <data name="Settings_Background_Note2" xml:space="preserve">
     <value>Note: Please prepare image files with the virtual desktop number as filename (e.g. "1.png", "2.png", ...).</value>
   </data>
+  <data name="Settings_Background_Position" xml:space="preserve">
+    <value>Choose a default position</value>
+  </data>
+  <data name="Settings_Background_Position_Center" xml:space="preserve">
+    <value>Center</value>
+  </data>
+  <data name="Settings_Background_Position_Fill" xml:space="preserve">
+    <value>Fill</value>
+  </data>
+  <data name="Settings_Background_Position_Fit" xml:space="preserve">
+    <value>Fit</value>
+  </data>
+  <data name="Settings_Background_Position_Span" xml:space="preserve">
+    <value>Span</value>
+  </data>
+  <data name="Settings_Background_Position_Stretch" xml:space="preserve">
+    <value>Stretch</value>
+  </data>
+  <data name="Settings_Background_Position_Tile" xml:space="preserve">
+    <value>Tile</value>
+  </data>
   <data name="Settings_Background_SelectionDialog" xml:space="preserve">
     <value>Select Background Images Folder</value>
   </data>

--- a/source/SylphyHorn/Services/ImageFormatSupportDetector.cs
+++ b/source/SylphyHorn/Services/ImageFormatSupportDetector.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using WindowsDesktop.Interop;
+
+namespace SylphyHorn.Services
+{
+	public abstract class ImageFormatSupportDetector
+	{
+		private bool? _isSupported = null;
+
+		public bool IsSupported
+		{
+			get
+			{
+				if (!this._isSupported.HasValue)
+				{
+					this._isSupported = this.GetValue();
+				}
+				return this._isSupported.Value;
+			}
+		}
+
+		public abstract string[] Extensions { get; }
+
+		public abstract string FileType { get; }
+
+		public abstract bool GetValue();
+	}
+
+	public abstract class ClsidImageFormatSupportDetector : ImageFormatSupportDetector
+	{
+		public abstract Guid CLSID { get; }
+
+		public override bool GetValue()
+		{
+			try
+			{
+				var decoderType = Type.GetTypeFromCLSID(this.CLSID);
+				var decoder = Activator.CreateInstance(decoderType);
+				return true;
+			}
+			catch (COMException ex) when (ex.Match(HResult.REGDB_E_CLASSNOTREG))
+			{
+				return false;
+			}
+		}
+	}
+}

--- a/source/SylphyHorn/Services/ImageFormatSupportDetectors.cs
+++ b/source/SylphyHorn/Services/ImageFormatSupportDetectors.cs
@@ -1,0 +1,103 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace SylphyHorn.Services
+{
+	public sealed class JpegXrSupportDetector : ClsidImageFormatSupportDetector
+	{
+		public override string[] Extensions => new string[] { ".wdp", ".jxr" };
+
+		public override string FileType => "JPEG XR";
+
+		public override Guid CLSID => new Guid(0xa26cec36, 0x234c, 0x4950, 0xae, 0x16, 0xe3, 0x4a, 0xac, 0xe7, 0x1d, 0x0d);
+	}
+
+	public sealed class WebPSupportDetector : ClsidImageFormatSupportDetector
+	{
+		public override string[] Extensions => new string[] { ".webp" };
+
+		public override string FileType => "WebP";
+
+		public override Guid CLSID => new Guid(0x7693e886, 0x51c9, 0x4070, 0x84, 0x19, 0x9f, 0x70, 0x73, 0x8e, 0xc8, 0xfa);
+	}
+
+	public sealed class HEIFSupportDetector : ClsidImageFormatSupportDetector
+	{
+		private bool? _isHEVCSupported;
+
+		public bool IsHEVCSupported
+		{
+			get
+			{
+				if (!this._isHEVCSupported.HasValue)
+				{
+					const string targetKeyName = "Microsoft.HEVCVideoExtension_";
+
+					this._isHEVCSupported = Registry.ClassesRoot
+						.OpenSubKey("ActivatableClasses")
+						.OpenSubKey("Package")
+						.GetSubKeyNames()
+						.Any(name => name.StartsWith(targetKeyName));
+				}
+				return this._isHEVCSupported.Value;
+			}
+		}
+
+		private bool? _isAV1Supported;
+
+		public bool IsAV1Supported
+		{
+			get
+			{
+				if (!this._isAV1Supported.HasValue)
+				{
+					const string targetKeyName = "Microsoft.AV1VideoExtension_";
+
+					this._isAV1Supported = Registry.ClassesRoot
+						.OpenSubKey("ActivatableClasses")
+						.OpenSubKey("Package")
+						.GetSubKeyNames()
+						.Any(name => name.StartsWith(targetKeyName));
+				}
+				return this._isAV1Supported.Value;
+			}
+		}
+
+		public override string[] Extensions
+		{
+			get
+			{
+				var extensions = new Collection<string> { ".heif", ".heifs", ".avci", ".avcs" };
+				if (this.IsHEVCSupported)
+				{
+					extensions.Add(".heic");
+					extensions.Add(".heics");
+				}
+				if (this.IsAV1Supported)
+				{
+					extensions.Add(".avif");
+					extensions.Add(".avifs");
+				}
+				return extensions.ToArray();
+			}
+		}
+
+		public override string FileType
+		{
+			get
+			{
+				return this.IsAV1Supported
+					? this.IsHEVCSupported
+						? "HEIF (AVCI, HEIC, AVIF)"
+						: "HEIF (AVCI, AVIF)"
+					: this.IsHEVCSupported
+						? "HEIF (AVCI, HEIC)"
+						: "HEIF (AVCI)";
+			}
+		}
+
+		public override Guid CLSID => new Guid(0xe9a4a80a, 0x44fe, 0x4de4, 0x89, 0x71, 0x71, 0x50, 0xb1, 0x0a, 0x51, 0x99);
+	}
+}

--- a/source/SylphyHorn/Services/ImageFormatSupportDetectors.cs
+++ b/source/SylphyHorn/Services/ImageFormatSupportDetectors.cs
@@ -65,6 +65,20 @@ namespace SylphyHorn.Services
 			}
 		}
 
+		private bool? _isAVIFSupported;
+
+		public bool IsAVIFSupported
+		{
+			get
+			{
+				if (!this._isAVIFSupported.HasValue)
+				{
+					this._isAVIFSupported = Environment.OSVersion.Version.Build >= 18305 && this.IsAV1Supported;
+				}
+				return this._isAVIFSupported.Value;
+			}
+		}
+
 		public override string[] Extensions
 		{
 			get
@@ -75,7 +89,7 @@ namespace SylphyHorn.Services
 					extensions.Add(".heic");
 					extensions.Add(".heics");
 				}
-				if (this.IsAV1Supported)
+				if (this.IsAVIFSupported)
 				{
 					extensions.Add(".avif");
 					extensions.Add(".avifs");
@@ -88,7 +102,7 @@ namespace SylphyHorn.Services
 		{
 			get
 			{
-				return this.IsAV1Supported
+				return this.IsAVIFSupported
 					? this.IsHEVCSupported
 						? "HEIF (AVCI, HEIC, AVIF)"
 						: "HEIF (AVCI, AVIF)"

--- a/source/SylphyHorn/Services/WallpaperService.cs
+++ b/source/SylphyHorn/Services/WallpaperService.cs
@@ -182,12 +182,12 @@ namespace SylphyHorn.Services
 		private static WallpaperPosition Parse(string options)
 		{
 			var options2 = options.ToLower();
+			if (options2.StartsWith("fil")) return WallpaperPosition.Fill;
+			if (options2.StartsWith("sp")) return WallpaperPosition.Span;
 			if (options2[0] == 'c') return WallpaperPosition.Center;
 			if (options2[0] == 't') return WallpaperPosition.Tile;
 			if (options2[0] == 's') return WallpaperPosition.Stretch;
 			if (options2[0] == 'f') return WallpaperPosition.Fit;
-			if (options2.StartsWith("fil")) return WallpaperPosition.Fill;
-			if (options2.StartsWith("sp")) return WallpaperPosition.Span;
 			return WallpaperPosition.Fit;
 		}
 	}

--- a/source/SylphyHorn/Services/WallpaperService.cs
+++ b/source/SylphyHorn/Services/WallpaperService.cs
@@ -52,7 +52,7 @@ namespace SylphyHorn.Services
 					var col = new Collection<WallpaperFile>();
 					foreach (var file in directoryInfo.GetFiles())
 					{
-						if (_supportedExtensions.Any(x => x == file.Extension))
+						if (_supportedExtensions.Any(x => string.Equals(x, file.Extension, StringComparison.OrdinalIgnoreCase)))
 						{
 							var wallpaper = WallpaperFile.CreateFromFile(file);
 							col.Add(wallpaper);

--- a/source/SylphyHorn/Services/WallpaperService.cs
+++ b/source/SylphyHorn/Services/WallpaperService.cs
@@ -13,7 +13,25 @@ namespace SylphyHorn.Services
 {
 	public class WallpaperService : IDisposable
 	{
-		private static readonly string[] _supportedExtensions = { ".png", ".jpg", ".jpeg", ".bmp", };
+		private static readonly ImageFormatSupportDetector[] detectors =
+		{
+			new JpegXrSupportDetector(),
+			new WebPSupportDetector(),
+			new HEIFSupportDetector(),
+		};
+
+		private static readonly string[] _defaultSupportedExtensions = { ".bmp", ".dib", ".gif", ".png", ".tif", ".tiff", ".jpe", ".jpg", ".jpeg", ".jfif" };
+		private static readonly string[] _supportedExtensions;
+
+		private static readonly string[] _defaultSupportedFileTypes = { "BMP", "GIF", "PNG", "TIFF", "JPEG" };
+
+		public static string[] SupportedFileTypes { get; }
+
+		static WallpaperService()
+		{
+			_supportedExtensions = _defaultSupportedExtensions.Concat(detectors.Where(d => d.IsSupported).SelectMany(d => d.Extensions)).ToArray();
+			SupportedFileTypes = _defaultSupportedFileTypes.Concat(detectors.Where(d => d.IsSupported).Select(d => d.FileType)).ToArray();
+		}
 
 		public static WallpaperService Instance { get; } = new WallpaperService();
 

--- a/source/SylphyHorn/SylphyHorn.csproj
+++ b/source/SylphyHorn/SylphyHorn.csproj
@@ -245,6 +245,8 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Services\ImageFormatSupportDetectors.cs" />
+    <Compile Include="Services\ImageFormatSupportDetector.cs" />
     <Compile Include="UI\Bindings\BindableTextViewModel.cs" />
     <Compile Include="UI\Bindings\HeaderContentViewModel.cs" />
     <Compile Include="UI\Bindings\WindowPlacement.cs" />
@@ -254,6 +256,7 @@
     <Compile Include="Startup.cs" />
     <Compile Include="UI\Controls\Keytop.cs" />
     <Compile Include="UI\Controls\UnlockImageConverter.cs" />
+    <Compile Include="UI\Controls\ArrayToStringConverter.cs" />
     <Compile Include="UI\DynamicInfoTrayIcon.cs" />
     <Compile Include="UI\NotificationWindow.cs" />
     <Compile Include="UI\PinWindow.xaml.cs">

--- a/source/SylphyHorn/SylphyHorn.csproj
+++ b/source/SylphyHorn/SylphyHorn.csproj
@@ -249,6 +249,7 @@
     <Compile Include="Services\ImageFormatSupportDetector.cs" />
     <Compile Include="UI\Bindings\BindableTextViewModel.cs" />
     <Compile Include="UI\Bindings\HeaderContentViewModel.cs" />
+    <Compile Include="UI\Bindings\WallpaperPosition.cs" />
     <Compile Include="UI\Bindings\WindowPlacement.cs" />
     <Compile Include="Services\LoggingService.cs" />
     <Compile Include="Services\MonitorService.cs" />

--- a/source/SylphyHorn/UI/Bindings/SettingsWindowViewModel.cs
+++ b/source/SylphyHorn/UI/Bindings/SettingsWindowViewModel.cs
@@ -25,6 +25,8 @@ namespace SylphyHorn.UI.Bindings
 
 		public IReadOnlyCollection<DisplayViewModel<string>> Cultures { get; }
 
+		public IReadOnlyCollection<DisplayViewModel<WallpaperPosition>> Positions { get; }
+
 		public IReadOnlyCollection<DisplayViewModel<WindowPlacement>> Placements { get; }
 
 		public bool IsDisplayEnabled { get; }
@@ -77,6 +79,24 @@ namespace SylphyHorn.UI.Bindings
 
 					this.RaisePropertyChanged();
 					this.RaisePropertyChanged(nameof(this.RestartRequired));
+				}
+			}
+		}
+
+		#endregion
+
+		#region Position notification property
+
+		public WallpaperPosition Position
+		{
+			get => (WallpaperPosition)Settings.General.Position.Value;
+			set
+			{
+				if ((WallpaperPosition)Settings.General.Position.Value != value)
+				{
+					Settings.General.Position.Value = (byte)value;
+
+					this.RaisePropertyChanged();
 				}
 			}
 		}
@@ -206,6 +226,16 @@ namespace SylphyHorn.UI.Bindings
 					.OrderBy(x => x.Display))
 				.ToList();
 
+			this.Positions = new[]
+			{
+				new DisplayViewModel<WallpaperPosition> { Display = Resources.Settings_Background_Position_Fill, Value = WallpaperPosition.Fill },
+				new DisplayViewModel<WallpaperPosition> { Display = Resources.Settings_Background_Position_Fit, Value = WallpaperPosition.Fit },
+				new DisplayViewModel<WallpaperPosition> { Display = Resources.Settings_Background_Position_Stretch, Value = WallpaperPosition.Stretch },
+				new DisplayViewModel<WallpaperPosition> { Display = Resources.Settings_Background_Position_Tile, Value = WallpaperPosition.Tile },
+				new DisplayViewModel<WallpaperPosition> { Display = Resources.Settings_Background_Position_Center, Value = WallpaperPosition.Center },
+				new DisplayViewModel<WallpaperPosition> { Display = Resources.Settings_Background_Position_Span, Value = WallpaperPosition.Span },
+			};
+
 			this.Placements = new[]
 			{
 				new DisplayViewModel<WindowPlacement> { Display = Resources.Settings_NotificationWindowPlacement_TopLeft, Value = WindowPlacement.TopLeft, },
@@ -240,7 +270,7 @@ namespace SylphyHorn.UI.Bindings
 			this._HasStartupLink = this._startup.IsExists;
 
 			Settings.General.DesktopBackgroundFolderPath
-				.Subscribe(path => this.Backgrounds = WallpaperService.Instance.GetWallpaperFiles(path))
+				.Subscribe(path => this.Backgrounds = WallpaperService.Instance.GetWallpaperFiles(path, (WallpaperPosition)Settings.General.Position.Value))
 				.AddTo(this);
 
 			var colAndWall = WallpaperService.GetCurrentColorAndWallpaper();

--- a/source/SylphyHorn/UI/Bindings/WallpaperPosition.cs
+++ b/source/SylphyHorn/UI/Bindings/WallpaperPosition.cs
@@ -1,0 +1,12 @@
+﻿namespace SylphyHorn.UI.Bindings
+{
+	public enum WallpaperPosition : byte
+	{
+		Center = 0,
+		Tile,
+		Stretch,
+		Fit,
+		Fill,
+		Span,
+	}
+}

--- a/source/SylphyHorn/UI/Controls/ArrayToStringConverter.cs
+++ b/source/SylphyHorn/UI/Controls/ArrayToStringConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+
+namespace SylphyHorn.UI.Converters
+{
+	public class ArrayToStringConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			return string.Join(parameter as string ?? ", ", value as object[]);
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/source/SylphyHorn/UI/Controls/UnlockImageConverter.cs
+++ b/source/SylphyHorn/UI/Controls/UnlockImageConverter.cs
@@ -19,7 +19,10 @@ namespace SylphyHorn.UI.Controls
 			{
 				if (DesignerProperties.GetIsInDesignMode(new DependencyObject())) return null;
 
-				using (var stream = new FileStream((string)value, FileMode.Open))
+				var filename = (string)value;
+				if (string.IsNullOrEmpty(filename)) return null;
+
+				using (var stream = new FileStream(filename, FileMode.Open))
 				{
 					var decoder = BitmapDecoder.Create(
 						stream,

--- a/source/SylphyHorn/UI/SettingsWindow.xaml
+++ b/source/SylphyHorn/UI/SettingsWindow.xaml
@@ -249,9 +249,11 @@
 															 MethodName="OpenBackgroundPathDialog"
 															 Margin="2" />
 								</Grid>
-								<TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_Background_Note1}"
-										   TextWrapping="Wrap"
-										   Margin="4,0,0,0" />
+								<TextBlock TextWrapping="Wrap"
+										   Margin="4,0,0,0">
+									<Run Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_Background_Note1, Mode=OneWay}" />
+									<Run Text="{Binding Source={x:Static services:WallpaperService.SupportedFileTypes}, Mode=OneWay, Converter={StaticResource ArrayToStringConverter}}" />
+								</TextBlock>
 								<Border Height="4" />
 								<TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_Background_Note2}"
 										   TextWrapping="Wrap"

--- a/source/SylphyHorn/UI/SettingsWindow.xaml
+++ b/source/SylphyHorn/UI/SettingsWindow.xaml
@@ -103,6 +103,24 @@
 					<Setter Property="Margin"
 							Value="0,8" />
 				</Style>
+				<Style x:Key="SubHeaderStyleKey"
+					   TargetType="{x:Type TextBlock}">
+					<Setter Property="Foreground"
+							Value="{DynamicResource ForegroundBrushKey}" />
+					<Setter Property="FontWeight"
+							Value="SemiBold" />
+					<Setter Property="Margin"
+							Value="8,4,8,4" />
+					<Setter Property="FontSize"
+							Value="13" />
+					<Style.Triggers>
+						<Trigger Property="IsEnabled"
+								 Value="False">
+							<Setter Property="Foreground"
+									Value="{DynamicResource InactiveForegroundBrushKey}" />
+						</Trigger>
+					</Style.Triggers>
+				</Style>
 				<Style x:Key="TabitemStyleKey"
 					   TargetType="{x:Type TextBlock}"
 					   BasedOn="{StaticResource VerticalTabHeaderTextStyleKey}">
@@ -232,9 +250,9 @@
 							<CheckBox IsChecked="{Binding Source={x:Static serialization:Settings.General}, Path=ChangeBackgroundEachDesktop.Value, Mode=TwoWay}">
 								<TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_Background_ChangeBackground}" />
 							</CheckBox>
-							<StackPanel Margin="16,0,0,0">
-								<Grid IsEnabled="{Binding Source={x:Static serialization:Settings.General}, Path=ChangeBackgroundEachDesktop.Value, Mode=TwoWay}"
-									  Margin="2">
+							<StackPanel IsEnabled="{Binding Source={x:Static serialization:Settings.General}, Path=ChangeBackgroundEachDesktop.Value, Mode=TwoWay}"
+										Margin="16,0,0,0">
+								<Grid Margin="2">
 									<Grid.ColumnDefinitions>
 										<ColumnDefinition MaxWidth="360" />
 										<ColumnDefinition Width="Auto" />
@@ -259,33 +277,53 @@
 										   TextWrapping="Wrap"
 										   Margin="4,0,0,0" />
 							</StackPanel>
-							<Border Height="16" />
-							<ItemsControl ItemsSource="{Binding Backgrounds}"
-										  Visibility="{Binding Source={x:Static serialization:Settings.General}, Path=ChangeBackgroundEachDesktop.Value, Converter={StaticResource BooleanToVisibilityConverter}}"
-										  Margin="18,0,0,0">
-								<ItemsControl.ItemsPanel>
-									<ItemsPanelTemplate>
-										<WrapPanel Orientation="Horizontal" />
-									</ItemsPanelTemplate>
-								</ItemsControl.ItemsPanel>
-								<ItemsControl.ItemTemplate>
-									<DataTemplate>
-										<DockPanel Margin="2">
-											<Label DockPanel.Dock="Top"
-												   Content="{Binding DesktopMonitorText}"
-												   Background="{DynamicResource ActiveBackgroundBrushKey}"
-												   Foreground="{DynamicResource ActiveForegroundBrushKey}"
-												   HorizontalContentAlignment="Center"
-												   Padding="8,1" />
-											<Image Source="{Binding Filepath, Converter={StaticResource UnlockImageConverter}, IsAsync=True}"
-												   Stretch="Uniform"
-												   VerticalAlignment="Top"
-												   MaxWidth="150" />
-										</DockPanel>
-									</DataTemplate>
-								</ItemsControl.ItemTemplate>
-							</ItemsControl>
 						</StackPanel>
+						<Border Height="12" />
+
+						<TextBlock Text="{Binding Source={x:Static services:ResourceService.Current}, Path=Resources.Settings_Background_Position}"
+								   Style="{DynamicResource SubHeaderStyleKey}"
+								   IsEnabled="{Binding Source={x:Static serialization:Settings.General}, Path=ChangeBackgroundEachDesktop.Value, Mode=TwoWay}" />
+						<StackPanel Margin="8,0,0,0">
+							<metro:PromptComboBox ItemsSource="{Binding Positions}"
+												  DisplayMemberPath="Display"
+												  SelectedValuePath="Value"
+												  SelectedValue="{Binding Position, Mode=TwoWay}"
+												  Prompt=""
+												  IsReadOnly="True"
+												  IsEnabled="{Binding Source={x:Static serialization:Settings.General}, Path=ChangeBackgroundEachDesktop.Value, Mode=OneWay}"
+												  MinWidth="160"
+												  Margin="1,0,0,0"
+												  HorizontalAlignment="Left" />
+						</StackPanel>
+						<Border Height="24" />
+
+						<ItemsControl ItemsSource="{Binding Backgrounds}"
+									  Visibility="{Binding Source={x:Static serialization:Settings.General}, Path=ChangeBackgroundEachDesktop.Value, Converter={StaticResource BooleanToVisibilityConverter}}"
+									  Margin="8,0,0,0"
+									  IsTabStop="False">
+							<ItemsControl.ItemsPanel>
+								<ItemsPanelTemplate>
+									<WrapPanel Orientation="Horizontal" />
+								</ItemsPanelTemplate>
+							</ItemsControl.ItemsPanel>
+							<ItemsControl.ItemTemplate>
+								<DataTemplate>
+									<DockPanel Margin="2">
+										<Label DockPanel.Dock="Top"
+											   Content="{Binding DesktopMonitorText}"
+											   Background="{DynamicResource ActiveBackgroundBrushKey}"
+											   Foreground="{DynamicResource ActiveForegroundBrushKey}"
+											   HorizontalContentAlignment="Center"
+											   Padding="8,1" />
+										<Image Source="{Binding Filepath, Converter={StaticResource UnlockImageConverter}, IsAsync=True}"
+											   Stretch="Uniform"
+											   VerticalAlignment="Top"
+											   Width="160"
+											   ToolTip="{Binding Filepath}" />
+									</DockPanel>
+								</DataTemplate>
+							</ItemsControl.ItemTemplate>
+						</ItemsControl>
 						<Border Height="8" />
 					</StackPanel>
 				</ScrollViewer>


### PR DESCRIPTION
### Changes

- Allow for capitalization of the extensions. (e.g. `.JPG`, `.pNg`)
- Support JPEG XR, WebP and HEIF image formats.
- Fixed an issue where `Fill` (fil) and `Span` (sp) didn't work in the per-wallpaper position method.
- Added feature to set the default position method (#38).
- Fixed an issue to throw an exception when the wallpaper isn't set.

<img src="https://user-images.githubusercontent.com/901816/89989199-95e48d00-dcbb-11ea-9d94-c162c43be2ee.png" width="720" height="600" alt="English">

---

### 変更点

- 拡張子の指定に大文字を許可。 (例 `.JPG`, `.pNg`)
- JPEG XR, WebP と HEIF画像フォーマットに対応。
- 壁紙ごとの配置方法で `Fill` (fil) と `Span` (sp) が正しく機能していなかった問題の修正。
- 既定の配置方法を設定できる項目の追加 (#38)。
- 壁紙が設定されていないとき例外が発生する問題の修正。

<img src="https://user-images.githubusercontent.com/901816/89989118-72b9dd80-dcbb-11ea-8991-bf2699beaf51.png" width="720" height="600" alt="Japanese">

---

In order to use each image format, the specific extensions are required.
- WebP: https://www.microsoft.com/store/productId/9PG2DK419DRG
- AVIF in HEIF (HEIF image extensions): https://www.microsoft.com/store/productId/9PMMSR1CGPWG
- HEIC in HEIF (HEIF image extensions are needed):
  - Software ver: https://www.microsoft.com/store/productId/9NMZLZ57R3T7
  - Manufacturer (Hardware) ver: https://www.microsoft.com/store/productId/9N4WGH0Z6VHQ
- AVIF in HEIF (HEIF image extensions are needed): https://www.microsoft.com/store/productId/9MVZQVXJBQ9V