### PR TITLE
Add a capability to disable animation.

### DIFF
--- a/source/SylphyHorn/UI/Controls/ClosingStoryboardBehavior.cs
+++ b/source/SylphyHorn/UI/Controls/ClosingStoryboardBehavior.cs
@@ -9,6 +9,18 @@ namespace SylphyHorn.UI.Controls
 	{
 		private bool _canClose;
 
+		#region IsEnabled 依存関係プロパティ
+
+		public bool IsEnabled
+		{
+			get { return (bool)this.GetValue(IsEnabledProperty); }
+			set { this.SetValue(IsEnabledProperty, value); }
+		}
+		public static readonly DependencyProperty IsEnabledProperty =
+			DependencyProperty.Register(nameof(IsEnabled), typeof(bool), typeof(ClosingStoryboardBehavior), new UIPropertyMetadata(true));
+
+		#endregion
+
 		#region Storyboard 依存関係プロパティ
 
 		public Storyboard Storyboard
@@ -42,7 +54,7 @@ namespace SylphyHorn.UI.Controls
 			base.OnAttached();
 			this.AssociatedObject.Closing += (sender, args) =>
 			{
-				if (this.Storyboard == null || args.Cancel || this._canClose) return;
+				if (this.Storyboard == null || args.Cancel || this._canClose || !this.IsEnabled) return;
 
 				args.Cancel = true;
 				this.Storyboard.Begin();

--- a/source/SylphyHorn/UI/PinWindow.xaml
+++ b/source/SylphyHorn/UI/PinWindow.xaml
@@ -53,7 +53,8 @@
 		<livet:WindowCloseCancelBehavior CloseCanceledCallbackMethodTarget="{Binding}"
 										 CloseCanceledCallbackMethodName="CloseCanceledCallback"
 										 CanClose="{Binding CanClose}" />
-		<controls:ClosingStoryboardBehavior Storyboard="{StaticResource FadeOut}" />
+		<controls:ClosingStoryboardBehavior Storyboard="{StaticResource FadeOut}"
+											IsEnabled="{DynamicResource {x:Static SystemParameters.MinimizeAnimationKey}}" />
 	</i:Interaction.Behaviors>
 	<i:Interaction.Triggers>
 		<i:EventTrigger EventName="ContentRendered">

--- a/source/SylphyHorn/UI/SwitchWindow.xaml
+++ b/source/SylphyHorn/UI/SwitchWindow.xaml
@@ -52,7 +52,8 @@
 		<livet:WindowCloseCancelBehavior CloseCanceledCallbackMethodTarget="{Binding}"
 										 CloseCanceledCallbackMethodName="CloseCanceledCallback"
 										 CanClose="{Binding CanClose}" />
-		<controls:ClosingStoryboardBehavior Storyboard="{StaticResource FadeOut}" />
+		<controls:ClosingStoryboardBehavior Storyboard="{StaticResource FadeOut}"
+											IsEnabled="{DynamicResource {x:Static SystemParameters.MinimizeAnimationKey}}" />
 	</i:Interaction.Behaviors>
 	<i:Interaction.Triggers>
 		<i:EventTrigger EventName="ContentRendered">


### PR DESCRIPTION
When `Animate controls and elements inside windows`

<img width="346" alt="スクリーンショット 2020-07-30 22 54 49" src="https://user-images.githubusercontent.com/901816/88931551-ede0c400-d2b7-11ea-8320-6d05ebb27b4a.png">

or `Show animation in Windows`

<img width="663" alt="スクリーンショット 2020-07-30 22 56 01" src="https://user-images.githubusercontent.com/901816/88931626-0bae2900-d2b8-11ea-8164-da456cff85ab.png">

is off, disable animation of `PinWindow` & `SwitchWindow`.
